### PR TITLE
Install the External-Secrets Controller

### DIFF
--- a/helm-values/external-secrets/README.md
+++ b/helm-values/external-secrets/README.md
@@ -1,0 +1,30 @@
+# Helm Values and bootstrapping External Secrets
+
+Since External Secrets needs to be deployable without another secrets process in place, we need to start by manually creating the secret containing the GCP creds. NOTE: We eventually want to switch the GKE cluster to using workload identity, after which this won't be necessary.
+
+## Create a namespace and secret
+
+The serivce account key is stored in the GCP secret manager. Start by retrieving the key from there, and saving it to your filesystem.
+
+Now, deploy the secret into a namespace called external-secrets.
+
+```
+kubectl create namespace external-secrets
+kubectl -n external-secrets create secret generic gcp-creds --from-file=gcp-creds.json=/tmp/gcp-creds.json
+```
+
+Remove the local copy of the credential key when you're done.
+
+## Deploying external secrets
+
+We're going to use helm to deploy the external secrets application, and pass in our override values here.
+
+```
+# If it's not there already, add the external-secrets helm repo to our helm installation
+helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
+```
+
+```
+# now, install external-secrets and pass in your values overrides with -f
+helm install -n external-secrets external-secrets external-secrets/kubernetes-external-secrets -f externalsecrets-values.yaml
+```

--- a/helm-values/external-secrets/externalsecrets-values.yaml
+++ b/helm-values/external-secrets/externalsecrets-values.yaml
@@ -1,0 +1,9 @@
+env:
+  POLLER_INTERVAL_MILLISECONDS: 120000
+  WATCH_TIMEOUT: 360000
+  GOOGLE_APPLICATION_CREDENTIALS: /app/gcp-creds/gcp-creds.json
+
+filesFromSecret:
+  gcp-creds:
+    secret: gcp-creds
+    mountPath: /app/gcp-creds

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.terraform.lock*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,7 +9,7 @@ This directory contains (or eventually will contain) the terraform definitions f
 
 ## terraform remote state
 
-To ensure that our infrastrucutre state is kept backed-up, and locked to prevent simultaneous exexecutions, the [terraform state](https://www.terraform.io/docs/language/state/index.html) files are kept in GCS buckets. Since I'd like the buckets to exist before terraform can store state in them, the buckets need to be created by hand, rather than managed with terraform. See the [Remote State](https://www.terraform.io/docs/language/settings/backends/gcs.html) docs for more info.
+To ensure that our infrastrucutre state is kept backed-up, and locked to prevent simultaneous executions, the [terraform state](https://www.terraform.io/docs/language/state/index.html) files are kept in GCS buckets. Since I'd like the buckets to exist before terraform can store state in them, the buckets need to be created by hand, rather than managed with terraform. See the [Remote State](https://www.terraform.io/docs/language/settings/backends/gcs.html) docs for more info.
 
 ## Inovking terraform
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,19 @@
+# Terraform configurations
+
+This directory contains (or eventually will contain) the terraform definitions for the infrastructure behind various clingen components.
+
+- `modules/` - Contains reusable terraform modules. Appropriate for shared code between environments
+- `dev/` - development environment configs
+- `stage/` - staging environment configs
+- `prod/` - production environment configs
+
+## terraform remote state
+
+To ensure that our infrastrucutre state is kept backed-up, and locked to prevent simultaneous exexecutions, the [terraform state](https://www.terraform.io/docs/language/state/index.html) files are kept in GCS buckets. Since I'd like the buckets to exist before terraform can store state in them, the buckets need to be created by hand, rather than managed with terraform. See the [Remote State](https://www.terraform.io/docs/language/settings/backends/gcs.html) docs for more info.
+
+## Inovking terraform
+
+To apply a configuration, cd into the desired env folder, and:
+
+- If it's the first time you've executed terraform, run `terraform init`.
+- Run a `terraform plan` to see the difference between the current configuration, and the actual infrastructure

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,4 +16,6 @@ To ensure that our infrastrucutre state is kept backed-up, and locked to prevent
 To apply a configuration, cd into the desired env folder, and:
 
 - If it's the first time you've executed terraform, run `terraform init`.
-- Run a `terraform plan` to see the difference between the current configuration, and the actual infrastructure
+- make the desired changes to the terraform manifests.
+- Run a `terraform plan` to see the difference between the current configuration, and the actual infrastructure.
+- If the plan looks good, run `terraform apply` to apply your changes (it will stop and ask you to confirm first). 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -3,55 +3,7 @@ provider "google" {
   region  = "us-east1"
 }
 
-# The IAM role that we'll use to allow read access to all GCP secrets within the project
-resource "google_project_iam_custom_role" "external-secrets-gsa" {
-  role_id     = "clingen_dev_external_secrets"
-  title       = "Clingen Dev Secret Manager Read Access"
-  description = "intended to allow the external-secrets controller to access secrets"
-  permissions = [
-    "resourcemanager.projects.get",
-    "secretmanager.locations.get",
-    "secretmanager.locations.list",
-    "secretmanager.secrets.get",
-    "secretmanager.secrets.getIamPolicy",
-    "secretmanager.secrets.list",
-    "secretmanager.versions.get",
-    "secretmanager.versions.list",
-    "secretmanager.versions.access",
-  ]
-}
-
-# The ServiceAccount that the external-secrets controller will use to identify itself to the GCP API.
-resource "google_service_account" "clingen-dev-external-secrets" {
-  account_id   = "clingen-dev-external-secrets"
-  display_name = "Clingen Dev External Secrets Controller"
-}
-
-# Bind the ServiceAccount to the IAM role.
-resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
-  role   = google_project_iam_custom_role.external-secrets-gsa.name
-  member = "serviceAccount:${google_service_account.clingen-dev-external-secrets.email}"
-}
-
-# Generate a key for the ServiceAccount, for the controller to authenticate with
-resource "google_service_account_key" "external_secrets_sa_key" {
-  service_account_id = google_service_account.clingen-dev-external-secrets.name
-}
-
-# create a secret to store the service account key in
-resource "google_secret_manager_secret" "external_secrets_sa_key_secret" {
-  secret_id = "external-secrets-serviceaccount-key"
-
-  replication {
-    automatic = true
-  }
-}
-
-# store the actual key data as a secret version
-# TODO: GKE clusters should be configured with Workload Identity, to avoid passing this key around:
-# https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-resource "google_secret_manager_secret_version" "external_secrets_key_version" {
-  secret = google_secret_manager_secret.external_secrets_sa_key_secret.id
-
-  secret_data = base64decode(google_service_account_key.external_secrets_sa_key.private_key)
+module "external-secrets" {
+  source = "../modules/external-secrets"
+  env = "dev"
 }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -40,7 +40,7 @@ resource "google_service_account_key" "external_secrets_sa_key" {
 
 # create a secret to store the service account key in
 resource "google_secret_manager_secret" "external_secrets_sa_key_secret" {
-  secret_id = "secret"
+  secret_id = "external-secrets-serviceaccount-key"
 
   replication {
     automatic = true
@@ -48,6 +48,8 @@ resource "google_secret_manager_secret" "external_secrets_sa_key_secret" {
 }
 
 # store the actual key data as a secret version
+# TODO: GKE clusters should be configured with Workload Identity, to avoid passing this key around:
+# https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 resource "google_secret_manager_secret_version" "external_secrets_key_version" {
   secret = google_secret_manager_secret.external_secrets_sa_key_secret.id
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  backend "gcs" {
+    bucket  = "clingen-tfstate-dev"
+    prefix  = "terraform/state"
+  }
+}
+
+provider "google" {
+  project     = "clingen-dev"
+  region      = "us-east1"
+}
+
+resource "google_project_iam_custom_role" "external-secrets-gsa" {
+  role_id     = "clingen_dev_external_secrets"
+  title       = "Clingen Dev Secret Manager Read Access"
+  description = "intended to allow the external-secrets controller to access secrets"
+  permissions = [
+    "resourcemanager.projects.get",
+    "secretmanager.locations.get",
+    "secretmanager.locations.list",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.getIamPolicy",
+    "secretmanager.secrets.list",
+    "secretmanager.versions.get",
+    "secretmanager.versions.list",
+    "secretmanager.versions.access",
+  ]
+}
+
+resource "google_service_account" "clingen-dev-external-secrets" {
+  account_id   = "clingen-dev-external-secrets"
+  display_name = "Clingen Dev External Secrets Controller"
+}
+
+resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
+  role   = google_project_iam_custom_role.external-secrets-gsa.name
+  member = "serviceAccount:${google_service_account.clingen-dev-external-secrets.email}"
+}
+
+

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,10 +1,3 @@
-terraform {
-  backend "gcs" {
-    bucket = "clingen-tfstate-dev"
-    prefix = "terraform/state"
-  }
-}
-
 provider "google" {
   project = "clingen-dev"
   region  = "us-east1"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -10,6 +10,7 @@ provider "google" {
   region      = "us-east1"
 }
 
+# The IAM role that we'll use to allow read access to all GCP secrets within the project
 resource "google_project_iam_custom_role" "external-secrets-gsa" {
   role_id     = "clingen_dev_external_secrets"
   title       = "Clingen Dev Secret Manager Read Access"
@@ -27,14 +28,15 @@ resource "google_project_iam_custom_role" "external-secrets-gsa" {
   ]
 }
 
+# The ServiceAccount that the external-secrets controller will use to identify itself to the GCP API.
 resource "google_service_account" "clingen-dev-external-secrets" {
   account_id   = "clingen-dev-external-secrets"
   display_name = "Clingen Dev External Secrets Controller"
 }
 
+# Bind the ServiceAccount to the IAM role.
 resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   role   = google_project_iam_custom_role.external-secrets-gsa.name
   member = "serviceAccount:${google_service_account.clingen-dev-external-secrets.email}"
 }
-
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -5,5 +5,5 @@ provider "google" {
 
 module "external-secrets" {
   source = "../modules/external-secrets"
-  env = "dev"
+  env    = "dev"
 }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,13 +1,13 @@
 terraform {
   backend "gcs" {
-    bucket  = "clingen-tfstate-dev"
-    prefix  = "terraform/state"
+    bucket = "clingen-tfstate-dev"
+    prefix = "terraform/state"
   }
 }
 
 provider "google" {
-  project     = "clingen-dev"
-  region      = "us-east1"
+  project = "clingen-dev"
+  region  = "us-east1"
 }
 
 # The IAM role that we'll use to allow read access to all GCP secrets within the project

--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -2,6 +2,6 @@
 
 resource "google_storage_bucket_iam_member" "member" {
   bucket = "clingen-tfstate-dev"
-  role = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectAdmin"
   member = "group:clingendevs@broadinstitute.org"
 }

--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -1,0 +1,7 @@
+# configs for managing access to the terraform state bucket
+
+resource "google_storage_bucket_iam_member" "member" {
+  bucket = "clingen-tfstate-dev"
+  role = "roles/storage.objectAdmin"
+  member = "group:clingendevs@broadinstitute.org"
+}

--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -5,3 +5,10 @@ resource "google_storage_bucket_iam_member" "member" {
   role   = "roles/storage.objectAdmin"
   member = "group:clingendevs@broadinstitute.org"
 }
+
+terraform {
+  backend "gcs" {
+    bucket = "clingen-tfstate-dev"
+    prefix = "terraform/state"
+  }
+}

--- a/terraform/modules/external-secrets/main.tf
+++ b/terraform/modules/external-secrets/main.tf
@@ -1,0 +1,52 @@
+# The IAM role that we'll use to allow read access to all GCP secrets within the project
+resource "google_project_iam_custom_role" "external-secrets-gsa" {
+  role_id     = "clingen_${var.env}_external_secrets"
+  title       = "Clingen ${var.env} Secret Manager Read Access"
+  description = "intended to allow the external-secrets controller to access secrets"
+  permissions = [
+    "resourcemanager.projects.get",
+    "secretmanager.locations.get",
+    "secretmanager.locations.list",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.getIamPolicy",
+    "secretmanager.secrets.list",
+    "secretmanager.versions.get",
+    "secretmanager.versions.list",
+    "secretmanager.versions.access",
+  ]
+}
+
+# The ServiceAccount that the external-secrets controller will use to identify itself to the GCP API.
+resource "google_service_account" "clingen-external-secrets" {
+  account_id   = "clingen-${var.env}-external-secrets"
+  display_name = "Clingen ${var.env} External Secrets Controller"
+}
+
+# Bind the ServiceAccount to the IAM role.
+resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
+  role   = google_project_iam_custom_role.external-secrets-gsa.name
+  member = "serviceAccount:${google_service_account.clingen-external-secrets.email}"
+}
+
+# Generate a key for the ServiceAccount, for the controller to authenticate with
+resource "google_service_account_key" "external_secrets_sa_key" {
+  service_account_id = google_service_account.clingen-external-secrets.name
+}
+
+# create a secret to store the service account key in
+resource "google_secret_manager_secret" "external_secrets_sa_key_secret" {
+  secret_id = "external-secrets-serviceaccount-key"
+
+  replication {
+    automatic = true
+  }
+}
+
+# store the actual key data as a secret version
+# TODO: GKE clusters should be configured with Workload Identity, to avoid passing this key around:
+# https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+resource "google_secret_manager_secret_version" "external_secrets_key_version" {
+  secret = google_secret_manager_secret.external_secrets_sa_key_secret.id
+
+  secret_data = base64decode(google_service_account_key.external_secrets_sa_key.private_key)
+}

--- a/terraform/modules/external-secrets/variables.tf
+++ b/terraform/modules/external-secrets/variables.tf
@@ -1,0 +1,4 @@
+variable "env" {
+  type = string
+  description = "The name of the environment we are deploying to. E.g. {dev,stage,prod}"
+}

--- a/terraform/modules/external-secrets/variables.tf
+++ b/terraform/modules/external-secrets/variables.tf
@@ -1,4 +1,4 @@
 variable "env" {
-  type = string
+  type        = string
   description = "The name of the environment we are deploying to. E.g. {dev,stage,prod}"
 }


### PR DESCRIPTION
This PR includes the work to install the external-secrets controller for syncing GCP Secrets Manager secrets, with kubernetes secrets.

Since the controller needs some IAM access, also included is the scaffold for terraform management, which will be augmented later to include management of other resources (such as our GKE clusters, etc).

This is still in progress, and I'll tag reviewers when I'm closer to getting the implementation done.