### PR TITLE
Add the ExternalSecret manifests for the dev secrets

### DIFF
--- a/services/dev/secrets/clinvar-raw-producer-kafka-dev-password.yaml
+++ b/services/dev/secrets/clinvar-raw-producer-kafka-dev-password.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-raw-producer-kafka-dev-password
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: clinvar-raw-producer-kafka-dev-password
+      name: kafka-dev-pass.txt
+      version: latest

--- a/services/dev/secrets/clinvar-raw-producer-kafka-dev-user.yaml
+++ b/services/dev/secrets/clinvar-raw-producer-kafka-dev-user.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-raw-producer-kafka-dev-user
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: clinvar-raw-producer-kafka-dev-user
+      name: kafka-dev-user.txt
+      version: latest

--- a/services/dev/secrets/clinvar-scv-kafka-password.yaml
+++ b/services/dev/secrets/clinvar-scv-kafka-password.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-scv-kafka-password
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: clinvar-scv-kafka-password
+      name: password
+      version: latest

--- a/services/dev/secrets/clinvar-scv-kafka-user.yaml
+++ b/services/dev/secrets/clinvar-scv-kafka-user.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-scv-kafka-user
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: clinvar-scv-kafka-user
+      name: user
+      version: latest

--- a/services/dev/secrets/clinvar-submissions-credentials.yaml
+++ b/services/dev/secrets/clinvar-submissions-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-submissions-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: clinvar-submissions-credentials
+      name: password
+      property: password
+      version: latest
+    - key: clinvar-submissions-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/dev/secrets/dx-dev-jaas.yaml
+++ b/services/dev/secrets/dx-dev-jaas.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-dev-jaas
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: dx-dev-jaas
+      name: password
+      version: latest

--- a/services/dev/secrets/dx-migration-credentials.yaml
+++ b/services/dev/secrets/dx-migration-credentials.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-migration-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: dx-migration-credentials
+      name: destination_pass
+      property: destination_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: destination_user
+      property: destination_user
+      version: latest
+    - key: dx-migration-credentials
+      name: key_pass
+      property: key_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: keystore_pass
+      property: keystore_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: truststore_pass
+      property: truststore_pass
+      version: latest

--- a/services/dev/secrets/dx-prod-jaas.yaml
+++ b/services/dev/secrets/dx-prod-jaas.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-prod-jaas
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: dx-prod-jaas
+      name: password
+      version: latest

--- a/services/dev/secrets/dx-stage-jaas.yaml
+++ b/services/dev/secrets/dx-stage-jaas.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-stage-jaas
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: dx-stage-jaas
+      name: password
+      version: latest

--- a/services/dev/secrets/gene-dosage-jira-credentials.yaml
+++ b/services/dev/secrets/gene-dosage-jira-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: gene-dosage-jira-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: gene-dosage-jira-credentials
+      name: password
+      property: password
+      version: latest
+    - key: gene-dosage-jira-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/dev/secrets/kafka-credentials.yaml
+++ b/services/dev/secrets/kafka-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kafka-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: kafka-credentials
+      name: password
+      property: password
+      version: latest
+    - key: kafka-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/dev/secrets/serveur-key-pass.yaml
+++ b/services/dev/secrets/serveur-key-pass.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: serveur-key-pass
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-dev
+  data:
+    - key: serveur-key-pass
+      name: password
+      version: latest


### PR DESCRIPTION
Using the work over at https://github.com/broadinstitute/tgg-sre-utils/blob/main/migrate_k8s_secrets/migrate_k8s_secrets.py, I've exported the secrets out of the genegraph-dev cluster, and into GCP Secret Manager. That script also spits out the ExternalSecret manifests that tell the external-secrets controller how to keep the GCP secrets in sync with kubernetes. Those manifests are in this PR.

A few notes:

- Before we merge this, we might want to verify that all the secrets look OK in GCP. Something could have gone wonky if we had anything in any of our secret values that can't serialize to json properly. I did a quick pass over things and didn't notice anything bad, but another pair of eyes would be good.
- For secrets with multiple fields, the result in GCP is that the secret is now a JSON dictionary, with the fields in the dictionary serving as the key names in the "data" field of the k8s secret. I didn't see any secrets where this JSON requirement was a problem, but we should think about the limitations that this might impose.
 
i.e.:

In GCP, the secret looks like:
```
{"password": "hunter2", "user": "zerocool"}
```

When synced to kubernetes, the Data field of the secret looks like this when you `kubectl describe` the secret:

```
Name:         zerocool-creds
Namespace:    default
Labels:       <none>
Annotations:  <none>

Type:  Opaque

Data
====
password:  6 bytes
user:     8 bytes
```