### PR TITLE
Terraform cloudbuild/firebase perms

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -7,3 +7,8 @@ module "external-secrets" {
   source = "../modules/external-secrets"
   env    = "dev"
 }
+
+module "cloudbuild-firebase" {
+  source = "../modules/cloudbuild-firebase"
+  project_id_number = "522856288592"
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -9,6 +9,6 @@ module "external-secrets" {
 }
 
 module "cloudbuild-firebase" {
-  source = "../modules/cloudbuild-firebase"
+  source            = "../modules/cloudbuild-firebase"
   project_id_number = "522856288592"
 }

--- a/terraform/modules/cloudbuild-firebase/main.tf
+++ b/terraform/modules/cloudbuild-firebase/main.tf
@@ -1,22 +1,10 @@
-data "google_service_account" "cloudbuild_default_serviceaccount" {
-  account_id = "${var.project_id_number}@cloudbuild.gserviceaccount.com"
-}
-
-data "google_iam_role" "firebase_admin_role" {
-  name = "roles/firebase.admin"
-}
-
-data "google_iam_role" "api_keys_admin_role" {
-  name = "roles/serviceusage.apiKeysAdmin"
-}
-
 # Grant the firebase roles to the cloudbuild serviceaccount
 resource "google_project_iam_member" "cloudbuild_firebase_binding" {
-  role   = google_project_iam_role.firebase_admin_role.name
-  member = "serviceAccount:${google_service_account.cloudbuild_default_serviceaccount.email}"
+  role   = "roles/firebase.admin"
+  member = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "cloudbuild_apikeys_binding" {
-  role   = google_project_iam_role.api_keys_admin_role.name
-  member = "serviceAccount:${google_service_account.cloudbuild_default_serviceaccount.email}"
+  role   = "roles/serviceusage.apiKeysAdmin"
+  member = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
 }

--- a/terraform/modules/cloudbuild-firebase/main.tf
+++ b/terraform/modules/cloudbuild-firebase/main.tf
@@ -1,0 +1,22 @@
+data "google_service_account" "cloudbuild_default_serviceaccount" {
+  account_id = "${var.project_id_number}@cloudbuild.gserviceaccount.com"
+}
+
+data "google_iam_role" "firebase_admin_role" {
+  name = "roles/firebase.admin"
+}
+
+data "google_iam_role" "api_keys_admin_role" {
+  name = "roles/serviceusage.apiKeysAdmin"
+}
+
+# Grant the firebase roles to the cloudbuild serviceaccount
+resource "google_project_iam_member" "cloudbuild_firebase_binding" {
+  role   = google_project_iam_role.firebase_admin_role.name
+  member = "serviceAccount:${google_service_account.cloudbuild_default_serviceaccount.email}"
+}
+
+resource "google_project_iam_member" "cloudbuild_apikeys_binding" {
+  role   = google_project_iam_role.api_keys_admin_role.name
+  member = "serviceAccount:${google_service_account.cloudbuild_default_serviceaccount.email}"
+}

--- a/terraform/modules/cloudbuild-firebase/variables.tf
+++ b/terraform/modules/cloudbuild-firebase/variables.tf
@@ -1,0 +1,4 @@
+variable "project_id_number" {
+  type        = string
+  description = "The project number prefix of the default service accounts"
+}

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -1,0 +1,9 @@
+provider "google" {
+  project = "clingen-stage"
+  region  = "us-east1"
+}
+
+module "cloudbuild-firebase" {
+  source = "../modules/cloudbuild-firebase"
+  project_id_number = "583560269534"
+}

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -4,6 +4,6 @@ provider "google" {
 }
 
 module "cloudbuild-firebase" {
-  source = "../modules/cloudbuild-firebase"
+  source            = "../modules/cloudbuild-firebase"
   project_id_number = "583560269534"
 }

--- a/terraform/stage/remote_state.tf
+++ b/terraform/stage/remote_state.tf
@@ -1,0 +1,14 @@
+# configs for managing access to the terraform state bucket
+
+resource "google_storage_bucket_iam_member" "member" {
+  bucket = "clingen-tfstate-stage"
+  role   = "roles/storage.objectAdmin"
+  member = "group:clingendevs@broadinstitute.org"
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "clingen-tfstate-stage"
+    prefix = "terraform/state"
+  }
+}


### PR DESCRIPTION
This adds a terraform module for granting the cloudbuild service account the necessary permissions to deploy to firebase.

As this is the first thing we're managing with terraform in staging, we also add a `stage/` directory with the basic bootstrapping to get terraform working there.

Closes #16 