### PR TITLE
External Secrets for staging

### DIFF
--- a/services/stage/secrets/clinvar-raw-credentials.yaml
+++ b/services/stage/secrets/clinvar-raw-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-raw-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: clinvar-raw-credentials
+      name: password
+      property: password
+      version: latest
+    - key: clinvar-raw-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/stage/secrets/clinvar-svc-kafka-password.yaml
+++ b/services/stage/secrets/clinvar-svc-kafka-password.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-scv-kafka-password
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: clinvar-scv-kafka-password
+      name: password
+      version: latest

--- a/services/stage/secrets/clinvar-svc-kafka-user.yaml
+++ b/services/stage/secrets/clinvar-svc-kafka-user.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: clinvar-scv-kafka-user
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: clinvar-scv-kafka-user
+      name: user
+      version: latest

--- a/services/stage/secrets/dx-migration-credentials.yaml
+++ b/services/stage/secrets/dx-migration-credentials.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-migration-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: dx-migration-credentials
+      name: destination_pass
+      property: destination_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: destination_user
+      property: destination_user
+      version: latest
+    - key: dx-migration-credentials
+      name: key_pass
+      property: key_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: keystore_pass
+      property: keystore_pass
+      version: latest
+    - key: dx-migration-credentials
+      name: truststore_pass
+      property: truststore_pass
+      version: latest

--- a/services/stage/secrets/dx-stage-jaas.yaml
+++ b/services/stage/secrets/dx-stage-jaas.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dx-stage-jaas
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: dx-stage-jaas
+      name: password
+      version: latest

--- a/services/stage/secrets/gene-dosage-jira-credentials.yaml
+++ b/services/stage/secrets/gene-dosage-jira-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: gene-dosage-jira-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: gene-dosage-jira-credentials
+      name: password
+      property: password
+      version: latest
+    - key: gene-dosage-jira-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/stage/secrets/kafka-credentials.yaml
+++ b/services/stage/secrets/kafka-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kafka-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: kafka-credentials
+      name: password
+      property: password
+      version: latest
+    - key: kafka-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/stage/secrets/neo4j-credentials.yaml
+++ b/services/stage/secrets/neo4j-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: neo4j-credentials
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: neo4j-credentials
+      name: password
+      property: password
+      version: latest
+    - key: neo4j-credentials
+      name: user
+      property: user
+      version: latest

--- a/services/stage/secrets/neo4j-url.yaml
+++ b/services/stage/secrets/neo4j-url.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: neo4j-url
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: neo4j-url
+      name: url
+      version: latest

--- a/services/stage/secrets/serveur-key-pass.yaml
+++ b/services/stage/secrets/serveur-key-pass.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: serveur-key-pass
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: serveur-key-pass
+      name: password
+      version: latest

--- a/services/stage/secrets/serveur-key.yaml
+++ b/services/stage/secrets/serveur-key.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: serveur-key
+spec:
+  backendType: gcpSecretsManager
+  projectId: clingen-stage
+  data:
+    - key: serveur-key
+      name: password
+      version: latest

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -7,3 +7,8 @@ module "cloudbuild-firebase" {
   source            = "../modules/cloudbuild-firebase"
   project_id_number = "583560269534"
 }
+
+module "external-secrets" {
+  source = "../modules/external-secrets"
+  env    = "stage"
+}


### PR DESCRIPTION
These are the terraform and manifest changes for making external secrets available in staging. Once merged, we can apply the terraform changes, and then follow the installation process in helm-values/external-secrets/README.md. This works towards #19 , and that work will be finished once the helm chart is deployed.