### PR TITLE
update submitter docker image release in staging

### DIFF
--- a/helm/values/clinvar-submitter/values-stage.yaml
+++ b/helm/values/clinvar-submitter/values-stage.yaml
@@ -2,3 +2,8 @@ ingress:
   static_ip_name: "global-stage-clinvar-submitter-ip"
   clinvar_hostnames:
   - "clinvar-submitter.stage.clingen.app"
+
+image:
+  repository: gcr.io/clingen-stage/clinvar-submitter
+  pullPolicy: Always
+  tag: "8f9ab0d75210f4589ab4e9fa1c04227178d979cc"


### PR DESCRIPTION
@larrybabb Just to illustrate how you'd release a new image, here's a change that updates the staging docker image to a recently built version.

Corresponding changes:
- **git commit in submitter**: https://github.com/clingen-data-model/clinvar-submitter/commit/8f9ab0d75210f4589ab4e9fa1c04227178d979cc
- **build trigger and build**: https://github.com/clingen-data-model/clinvar-submitter/runs/2422889344 / https://console.cloud.google.com/cloud-build/builds;region=global/9f0c437e-c7c2-4540-b504-f0a784e9b401?project=clingen-stage

After merging this PR, Argo should pick up the change (typically between 0-3 minutes) and apply the change to staging.