### PR TITLE
renames the managed certs in the helm chart, to remove a conflict

### DIFF
--- a/helm/charts/clingen-genegraph/templates/genegraph-ingress.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ include "clingen-genegraph.chartLabels" . | indent 4 }}
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.genegraph_static_ip_name }}
-    networking.gke.io/managed-certificates: {{ .Values.genegraph_mcrt_name }}
+    networking.gke.io/managed-certificates: {{ .Release.Name }}-certificate
     kubernetes.io/ingress.class: "gce"
 spec:
   backend:

--- a/helm/charts/clingen-genegraph/templates/tls-cert.yaml
+++ b/helm/charts/clingen-genegraph/templates/tls-cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
-  name: {{ .Values.genegraph_mcrt_name }}
+  name: {{ .Release.Name }}-certificate
   labels:
 {{ include "clingen-genegraph.chartLabels" . | indent 4 }}
 spec:

--- a/helm/values/genegraph-clinvar/values-dev.yaml
+++ b/helm/values/genegraph-clinvar/values-dev.yaml
@@ -23,7 +23,6 @@ genegraph_local_ssd: false
 
 # certificate and ingress
 genegraph_tls_cert: true
-genegraph_mcrt_name: genegraph-clinvar-certificate
 genegraph_mcrt_domains:
 - 'genegraph-dev.clingen.app'
 genegraph_configure_ingress: true

--- a/helm/values/genegraph-clinvar/values-dev.yaml
+++ b/helm/values/genegraph-clinvar/values-dev.yaml
@@ -23,7 +23,7 @@ genegraph_local_ssd: false
 
 # certificate and ingress
 genegraph_tls_cert: true
-genegraph_mcrt_name: clingen-app-certificate
+genegraph_mcrt_name: genegraph-clinvar-certificate
 genegraph_mcrt_domains:
 - 'genegraph-dev.clingen.app'
 genegraph_configure_ingress: true

--- a/helm/values/genegraph-gvdev/values-dev.yaml
+++ b/helm/values/genegraph-gvdev/values-dev.yaml
@@ -21,7 +21,6 @@ genegraph_liveness_probe: false
 
 # certificate and ingress
 genegraph_tls_cert: true
-genegraph_mcrt_name: genegraph-gvdev-certificate
 genegraph_mcrt_domains:
 - 'genegraph-gvdev.clingen.app'
 genegraph_configure_ingress: true

--- a/helm/values/genegraph-gvdev/values-dev.yaml
+++ b/helm/values/genegraph-gvdev/values-dev.yaml
@@ -21,7 +21,7 @@ genegraph_liveness_probe: false
 
 # certificate and ingress
 genegraph_tls_cert: true
-genegraph_mcrt_name: gvdev-app-certificate
+genegraph_mcrt_name: genegraph-gvdev-certificate
 genegraph_mcrt_domains:
 - 'genegraph-gvdev.clingen.app'
 genegraph_configure_ingress: true

--- a/services/dev/genegraph/tls-cert.yaml
+++ b/services/dev/genegraph/tls-cert.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
     domains:
     # - 'clingen.app'
-    - 'genegraph-dev.clingen.app'
     - 'genegraph-gvdev.clingen.app'
     # - '*.clingen.app'


### PR DESCRIPTION
The old static k8s manifests created a managed cert called `clingen-app-certificate` which is a name I reused in the clinvar helm templates. When deploying, using the same name caused it to clobber the old cert. This change uses a derived name for the cert, so that it'll use a different certificate name for each genegraph deployment.