### PR TITLE
Configure linting and kubernetes manifest validation

### DIFF
--- a/dockerfiles/git-image-updater/Dockerfile
+++ b/dockerfiles/git-image-updater/Dockerfile
@@ -1,7 +1,10 @@
-FROM gcr.io/cloud-builders/git
+FROM ubuntu:20.04
 
 RUN apt-get update \
-  && apt-get install -y wget \
+  && apt-get install -y --no-install-recommends \
+     wget \
+     git \
+     ca-certificates \
   && wget https://github.com/mikefarah/yq/releases/download/v4.7.1/yq_linux_amd64 -O /usr/bin/yq \
   && chmod +x /usr/bin/yq \
   && wget https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_amd64.tar.gz -O /tmp/gh-cli.tar.gz \

--- a/dockerfiles/helm-linter/Dockerfile
+++ b/dockerfiles/helm-linter/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+     wget \
+     git \
+     ca-certificates \
+  && wget https://github.com/roboll/helmfile/releases/download/v0.139.5/helmfile_linux_amd64 -O /usr/bin/helmfile \
+  && chmod +x /usr/bin/helmfile \
+  && wget https://github.com/yannh/kubeconform/releases/download/v0.4.7/kubeconform-linux-amd64.tar.gz -O /tmp/kubeconform.tar.gz \
+  && tar -C /usr/bin -xzf /tmp/kubeconform.tar.gz kubeconform \
+  && rm /tmp/kubeconform.tar.gz \
+  && wget https://get.helm.sh/helm-v3.5.4-linux-amd64.tar.gz -O /tmp/helm.tar.gz \
+  && tar -C /usr/bin -xzf /tmp/helm.tar.gz linux-amd64/helm --strip-components=1 \
+  && rm /tmp/helm.tar.gz \
+  && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/bin/bash"]

--- a/dockerfiles/helm-linter/cloudbuild.yaml
+++ b/dockerfiles/helm-linter/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/helm-linter', '.']
+
+images:
+- 'gcr.io/$PROJECT_ID/helm-linter'

--- a/helm/charts/clingen-argocd/README.md
+++ b/helm/charts/clingen-argocd/README.md
@@ -1,6 +1,6 @@
 # Umbrella helm chart for deploying the clingen argocd instance
 
-This helm chart pulls in the upstream argo-cd helm chart from the [argo-helm repository](https://argoproj.github.io/argo-helm). The idea is that we provide any resources which are required on our end, in the templates directory, and then pass in the variable values that we want into the argo-cd chart using the values.yaml file.
+This helm chart pulls in the upstream argo-cd helm chart from the [argo-helm repository](https://argoproj.github.io/argo-helm). The idea is that we provide any resources which are required on our end in the templates directory, and then pass in the variable values that we want into the argo-cd chart using the values.yaml file.
 
 ## Installing argo in clingen
 

--- a/helm/charts/clingen-argocd/README.md
+++ b/helm/charts/clingen-argocd/README.md
@@ -1,6 +1,6 @@
 # Umbrella helm chart for deploying the clingen argocd instance
 
-This helm chart pulls in the upstream argo-cd helm chart from the [argo-helm repository](https://argoproj.github.io/argo-helm). The idea, is that we provide any resources which are required on our end, in the templates directory, and then pass in the variable values that we want into the argo-cd chart using the values.yaml file.
+This helm chart pulls in the upstream argo-cd helm chart from the [argo-helm repository](https://argoproj.github.io/argo-helm). The idea is that we provide any resources which are required on our end, in the templates directory, and then pass in the variable values that we want into the argo-cd chart using the values.yaml file.
 
 ## Installing argo in clingen
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint charts/$chart
-        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
+        helmfile -q -l template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
       done
 
 # timeout if not complete in 10 minutes

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -4,7 +4,6 @@
 # gcloud builds submit --project=clingen-stage --config ./cloudbuild.yaml \
 #  --substitutions=COMMIT_SHA="testbuild" .
 
-# Builds clinvar-submitter and tags for both stage and prod image repositories
 steps:
 - name: 'gcr.io/clingen-stage/helm-linter'
   args: 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
       cd helm/
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
-        helm lint charts/$chart
+        helm lint --with-subcharts=false charts/$chart
         helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
       done
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
     - '-c'
     - |-
       declare -a changed=($(git diff-tree --no-commit-id --name-only -r $COMMIT_SHA | grep '^helm/charts' | cut -d/ -f 3))
+      echo "changed charts: ${changed[@]}"
       cd helm/
       for chart in ${changed[@]}; do
         echo "===== Linting $chart ====="

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -12,10 +12,8 @@ steps:
     - 'pipefail'
     - '-c'
     - |-
-      declare -a changed=($(git diff-tree --no-commit-id --name-only -r $COMMIT_SHA | grep '^helm/charts' | cut -d/ -f 3))
-      echo "changed charts: ${changed[@]}"
       cd helm/
-      for chart in ${changed[@]}; do
+      for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint charts/$chart
         helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       for chart in ${changed[@]}; do
         echo "===== Linting $chart ====="
         helm lint charts/$chart
-        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate" -verbose
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
       done
 
 # timeout if not complete in 10 minutes

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint charts/$chart
-        helmfile -q -l template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
       done
 
 # timeout if not complete in 10 minutes

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# Cloud Build configuration for linting helm charts
+#
+# Command line test usage:
+# gcloud builds submit --project=clingen-stage --config ./cloudbuild.yaml \
+#  --substitutions=COMMIT_SHA="testbuild" .
+
+# Builds clinvar-submitter and tags for both stage and prod image repositories
+steps:
+- name: 'gcr.io/clingen-stage/helm-linter'
+  args: 
+    - '-euo'
+    - 'pipefail'
+    - '-c'
+    - |-
+      declare -a changed=($(git diff-tree --no-commit-id --name-only -r $COMMIT_SHA | grep '^helm/charts' | cut -d/ -f 3))
+      for i in ${changed[@]}; do echo "$i"; done
+
+# timeout if not complete in 30 minutes
+timeout: 1800s

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -13,7 +13,12 @@ steps:
     - '-c'
     - |-
       declare -a changed=($(git diff-tree --no-commit-id --name-only -r $COMMIT_SHA | grep '^helm/charts' | cut -d/ -f 3))
-      for i in ${changed[@]}; do echo "$i"; done
+      cd helm/
+      for chart in ${changed[@]}; do
+        echo "===== Linting $chart ====="
+        helm lint charts/$chart
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate" -verbose
+      done
 
-# timeout if not complete in 30 minutes
-timeout: 1800s
+# timeout if not complete in 10 minutes
+timeout: 600s

--- a/helm/helmfile.d/dev.yaml
+++ b/helm/helmfile.d/dev.yaml
@@ -14,3 +14,6 @@ releases:
     chart: ../charts/clingen-genegraph
     values:
     - ../values/genegraph-clinvar/values-dev.yaml
+  - name: clingen-anyvar
+    namespace: default
+    chart: ../charts/clingen-anyvar

--- a/helm/helmfile.d/dev.yaml
+++ b/helm/helmfile.d/dev.yaml
@@ -1,0 +1,16 @@
+releases:
+  - name: genegraph
+    namespace: default
+    chart: ../charts/clingen-genegraph
+    values:
+    - ../values/genegraph/values-dev.yaml
+  - name: genegraph-gvdev
+    namespace: default
+    chart: ../charts/clingen-genegraph
+    values:
+    - ../values/genegraph-gvdev/values-dev.yaml
+  - name: genegraph-clinvar
+    namespace: default
+    chart: ../charts/clingen-genegraph
+    values:
+    - ../values/genegraph-clinvar/values-dev.yaml

--- a/helm/helmfile.d/prod.yaml
+++ b/helm/helmfile.d/prod.yaml
@@ -1,3 +1,6 @@
+repositories:
+  - name: argo
+    url: https://argoproj.github.io/argo-helm
 releases:
   - name: genegraph
     namespace: default

--- a/helm/helmfile.d/prod.yaml
+++ b/helm/helmfile.d/prod.yaml
@@ -4,3 +4,7 @@ releases:
     chart: ../charts/clingen-genegraph
     values:
     - ../values/genegraph/values-prod.yaml
+  - name: clingen-argocd
+    namespace: argocd
+    chart: ../charts/clingen-argocd
+

--- a/helm/helmfile.d/prod.yaml
+++ b/helm/helmfile.d/prod.yaml
@@ -1,0 +1,6 @@
+releases:
+  - name: genegraph
+    namespace: default
+    chart: ../charts/clingen-genegraph
+    values:
+    - ../values/genegraph/values-prod.yaml

--- a/helm/helmfile.d/stage.yaml
+++ b/helm/helmfile.d/stage.yaml
@@ -1,0 +1,11 @@
+releases:
+  - name: stage-clingen-clinvar-submitter
+    namespace: submitter
+    chart: ../charts/clingen-clinvar-submitter
+    values:
+      - ../values/clinvar-submitter/values-stage.yaml
+  - name: genegraph
+    namespace: default
+    chart: ../charts/clingen-genegraph
+    values:
+    - ../values/genegraph/values-stage.yaml

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -1,13 +1,13 @@
 # clinvar-submitter build
 resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
-  name = "clinvar-submitter-stage-build"
+  name        = "clinvar-submitter-stage-build"
   description = "Build clinvar submitter on push to master"
 
   github {
-    name   = "clinvar-submitter"
-    owner       = "clingen-data-model"
+    name  = "clinvar-submitter"
+    owner = "clingen-data-model"
     push {
-        branch = "^master$"
+      branch = "^master$"
     }
   }
 
@@ -16,11 +16,11 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
 
 # architecture helm chart linting
 resource "google_cloudbuild_trigger" "architecture_helm_lint" {
-  name = "architecture-helm-pr-lint"
+  name        = "architecture-helm-pr-lint"
   description = "lint helm charts in architecture when they've changed"
 
   github {
-    name = "architecture"
+    name  = "architecture"
     owner = "clingen-data-model"
     pull_request {
       branch = "^master$"

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -1,3 +1,4 @@
+# clinvar-submitter build
 resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
   name = "clinvar-submitter-stage-build"
   description = "Build clinvar submitter on push to master"
@@ -11,4 +12,24 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
   }
 
   filename = "cloudbuild.yaml"
+}
+
+# architecture helm chart linting
+resource "google_cloudbuild_trigger" "architecture_helm_lint" {
+  name = "architecture-helm-pr-lint"
+  description = "lint helm charts in architecture when they've changed"
+
+  github {
+    name = "architecture"
+    owner = "clingen-data-model"
+    pull_request {
+      branch = "^master$"
+    }
+  }
+
+  included_files = [
+    "helm/**"
+  ]
+
+  filename = "helm/cloudbuild.yaml"
 }


### PR DESCRIPTION
To avoid mistakes, I'd like to configure linting for the helm charts within this repository. Linting helm charts is kind of a tricky task: 

1. The helm chart itself needs to be linted with `helm lint`. 
2. The rendered output of the helm chart needs to be YAML-linted. The templates themselves are not valid YAML, so we can't lint the YAML without rendering the chart. I've found that https://github.com/roboll/helmfile is a useful tool for easily rendering all the different flavors of a helm chart at the same time.
3. Once we have a rendered chart and have checked the YAML for syntax correctness, we also need to validate that the manifests conform to the kubernetes API schema for each resource. This step is necessary because you can write perfectly valid YAML that kubernetes won't know what to do with. To catch the most mistakes before deploy time, I think we can employ the following workflow:

- on a change in the helm/{charts,values} directories, `helm lint` the charts that have changed.
- render the various versions (e.g. dev/stg/prod genegraph, genegraph-clinvar, etc) of each chart that has changed with `helmfile template`
- pipe the rendered manifests to https://github.com/yannh/kubeconform for schema validation

In my testing so far, the process of rendering helm charts seems to catch enough of the YAML errors that I don't think we need an explicit yaml linting step, but something like `yamllint` could be employed.

I've started with creating helmfiles that allow me to render multiple versions of each of our charts, and will be working on the subsequent steps.

Closes #30 