### PR TITLE
add documented policy bindings for ci-cd and cloud functions

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -27,3 +27,16 @@ module "prod-gke-cluster" {
     managed_by = "terraform"
   }
 }
+
+# IAM bindings for the clinvarSCV cloud functions
+resource "google_service_account_iam_member" "cloudbuild_appspot_binding" {
+  service_account_id = "projects/clingen-dx/serviceAccounts/clingen-dx@appspot.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "cloudbuild_cloudfunctions_grant" {
+  role   = "roles/cloudfunctions.developer"
+  member = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}
+


### PR DESCRIPTION
Unsure what our desires are on deploying the clinvarsvc cloud function are yet, but assuming we want to follow a process similar to: https://cloud.google.com/functions/docs/testing/test-cicd (cloudbuild pipeline to test the function, and then deploy it to the clingen-dx project after success)

These should be the IAM policy grants required, according to the documentation, to allow cloudbuild to publish a cloud function.

I'll wait to merge this one until we've had a chance to go over what we'd like the deploy process to look like