### PR TITLE
Add argo app manifests

### DIFF
--- a/services/dev/argo/dev-anyvar.yaml
+++ b/services/dev/argo/dev-anyvar.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-anyvar
+  namespace: argocd
+spec:
+  project: dev
+  source:
+    repoURL: https://github.com/clingen-data-model/architecture.git
+    targetRevision: HEAD
+    path: helm/charts/clingen-anyvar
+  destination:
+    server: https://35.237.22.18
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false

--- a/services/dev/argo/dev-secrets.yaml
+++ b/services/dev/argo/dev-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-secrets
+  namespace: argocd
+spec:
+  project: dev
+  source:
+    repoURL: https://github.com/clingen-data-model/architecture.git
+    targetRevision: HEAD
+    path: services/dev/secrets
+  destination:
+    server: https://35.237.22.18
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false

--- a/services/prod/argo/prod-secrets.yaml
+++ b/services/prod/argo/prod-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-secrets
+  namespace: argocd
+spec:
+  project: prod
+  source:
+    repoURL: https://github.com/clingen-data-model/architecture.git
+    targetRevision: HEAD
+    path: services/prod/secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false

--- a/services/prod/argo/prod-secrets.yaml
+++ b/services/prod/argo/prod-secrets.yaml
@@ -12,7 +12,4 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: default
-  syncPolicy:
-    automated:
-      prune: false
-      selfHeal: false
+  syncPolicy: {}

--- a/services/stage/argo/stage-clingen-clinvar-submitter.yaml
+++ b/services/stage/argo/stage-clingen-clinvar-submitter.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-clingen-clinvar-submitter
+  namespace: argocd
+spec:
+  project: stage
+  source:
+    repoURL: https://github.com/clingen-data-model/architecture.git
+    targetRevision: HEAD
+    path: helm/charts/clingen-clinvar-submitter
+    helm:
+      valueFiles:
+      - ../../values/clinvar-submitter/values-stage.yaml
+  destination:
+    server: https://35.185.65.146
+    namespace: submitter
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false

--- a/services/stage/argo/stage-secrets.yaml
+++ b/services/stage/argo/stage-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-secrets
+  namespace: argocd
+spec:
+  project: stage
+  source:
+    repoURL: https://github.com/clingen-data-model/architecture.git
+    targetRevision: HEAD
+    path: services/stage/secrets
+  destination:
+    server: https://35.185.65.146
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false


### PR DESCRIPTION
Argo allows you to define deployments using a kubernetes manifest. These manifests will allow us to keep the deployment configs for argo in code, so that we don't have to rely on making updates in the web interface.

Closes #32 