### PR TITLE
bind bigquery.dataViewer to clingen-stage appspot user

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -40,3 +40,9 @@ resource "google_project_iam_member" "cloudbuild_cloudfunctions_grant" {
   member = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
 }
 
+# IAM binding for allowing staging clinvarSCV function to run prod bigquery
+resource "google_bigquery_dataset_iam_member" "stage_appspot_sa" {
+  dataset_id = "projects/clingen-dx/datasets/clinvar_qa"
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:clingen-stage@appspot.gserviceaccount.com"
+}


### PR DESCRIPTION
My understanding is that in order for the staging cloudfunctions service account to be able to read data from prod bigquery tables, we need to grant it the bigquery.dataViewer role. This tf config should grant that role to that user, on the clinvar_qa dataset.