### PR TITLE
define the clinvar scv cloudfunction build/deploy trigger

### DIFF
--- a/terraform/prod/cloudbuild_triggers.tf
+++ b/terraform/prod/cloudbuild_triggers.tf
@@ -7,7 +7,7 @@ resource "google_cloudbuild_trigger" "clinvar_scv_prod" {
   github {
     name  = "clinvar-submitter"
     owner = "clingen-data-model"
-    pull_request {
+    push {
       branch = "^master$"
     }
   }
@@ -15,4 +15,6 @@ resource "google_cloudbuild_trigger" "clinvar_scv_prod" {
   included_files = [
     "gcp/function-source/*"
   ]
+
+  filename = "gcp/function-source/cloudbuild.yaml"
 }

--- a/terraform/prod/cloudbuild_triggers.tf
+++ b/terraform/prod/cloudbuild_triggers.tf
@@ -1,0 +1,18 @@
+# trigger for the prod ClinvarSCV cloudfunction deployment
+resource "google_cloudbuild_trigger" "clinvar_scv_prod" {
+  name        = "ClinVarSCVChange"
+  description = "Redeploy ClinVarSCV Cloud Function Trigger"
+  disabled    = true
+
+  github {
+    name  = "clinvar-submitter"
+    owner = "clingen-data-model"
+    pull_request {
+      branch = "^master$"
+    }
+  }
+
+  included_files = [
+    "gcp/function-source/*"
+  ]
+}


### PR DESCRIPTION
This defines the only cloudbuild trigger that we currently have in prod (which is disabled).

Same process here as the one in #79 -- I'll `terraform import` the existing resource, and then apply it once I'm sure the syntax looks right.

The one change that this will introduce, is to fix a typo in the description field.

closes #78 