### PR TITLE
Update argocd to the latest upstream helm release

### DIFF
--- a/helm/charts/clingen-argocd/Chart.lock
+++ b/helm/charts/clingen-argocd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 3.0.0
-digest: sha256:efb28e552f304f5f52cb5ea36207d1bc2f2375ce990550a123184277356f6935
-generated: "2021-04-07T22:34:08.598002-04:00"
+  version: 3.6.8
+digest: sha256:2b8e16280e1f1e9d99c055a069ccda2a1c8bc90686b62c41fa2f74af23c4cdf0
+generated: "2021-06-17T11:50:36.864168-04:00"

--- a/helm/charts/clingen-argocd/Chart.yaml
+++ b/helm/charts/clingen-argocd/Chart.yaml
@@ -3,5 +3,5 @@ name: clingen-argocd
 version: 1.0.0
 dependencies:
   - name: argo-cd
-    version: 3.0.0
+    version: 3.6.8
     repository: https://argoproj.github.io/argo-helm

--- a/helm/charts/clingen-argocd/README.md
+++ b/helm/charts/clingen-argocd/README.md
@@ -24,6 +24,25 @@ cd <repo>/helm
 helm install -n argocd clingen-argocd charts/clingen-argocd
 ```
 
+## Updating argo in clingen
+
+To update our argocd release, first update the argo-cd dependency in Chart.yaml to the desired version, then run the dependency update to pull down the new version of the official argocd helm chart:
+
+```
+helm dependency update
+```
+
+This will also update our Chart.lock file with the new version and SHA sum.
+
+To push the update out, ensure your kubectl it pointed at the prod clingen cluster, and run:
+
+```
+cd <repo>/helm
+helm upgrade --install -n argocd clingen-argocd charts/clingen-argocd
+```
+
+This will cause all the pods to restart in the argocd namespace, so it's important to do this when there are no planned deployments.
+
 ## Manual configuration
 
 ### Github authentication

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint --with-subcharts=false charts/$chart
-        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose -kubernetes-version "1.19.9"
       done
 
 # timeout if not complete in 10 minutes


### PR DESCRIPTION
We were running version 3.0.0 of the upstream helm chart, this updates us to 3.6.8 of that chart, which corresponds with ArgoCD 2.0.3. Added docs to the readme to indicate the upgrade procedure.