### PR TITLE
small argo config tweaks to reduce log spam

### DIFF
--- a/helm/charts/clingen-argocd/values.yaml
+++ b/helm/charts/clingen-argocd/values.yaml
@@ -6,7 +6,15 @@ argo_url: &argourl https://argocd.prod.clingen.app # sadly, we can't concat stri
 # values to pass on to the argocd subchart
 argo-cd:
   installCRDs: false
+  controller:
+    logLevel: warn
+    logFormat: json
+  repoServer:
+    logLevel: warn
+    logFormat: json
   server:
+    logLevel: warn
+    logFormat: json
     service:
       namedTargetPort: false
       annotations:

--- a/helm/values/argocd-notifications/values-prod.yaml
+++ b/helm/values/argocd-notifications/values-prod.yaml
@@ -1,4 +1,5 @@
 argocdUrl: "https://argocd.prod.clingen.app"
+logLevel: warn
 secret:
   create: false
 subscriptions:


### PR DESCRIPTION
The default INFO level logging in argo is quite verbose. Now that it's been running stable for a bit, I think it's appropriate to adjust the log level to get rid of some of the noise.