### PR TITLE
update clinvar submitter to the stable networking API

### DIFF
--- a/helm/charts/clingen-clinvar-submitter/templates/ingress.yaml
+++ b/helm/charts/clingen-clinvar-submitter/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "clingen-clinvar-submitter.fullname" . }}-ingress
@@ -9,6 +9,14 @@ metadata:
     networking.gke.io/managed-certificates: {{ include "clingen-clinvar-submitter.fullname" . }}-certificate
     kubernetes.io/ingress.class: "gce"
 spec:
-  backend:
-    serviceName: {{ include "clingen-clinvar-submitter.fullname" . }}
-    servicePort: {{ .Values.service.port }}
+  rules:
+    - host: {{ first .Values.ingress.clinvar_hostnames }}
+      http:
+        paths:
+          - path: /*
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "clingen-clinvar-submitter.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}


### PR DESCRIPTION
Noticed the following warning in the helm linter logs:

> [WARNING] templates/ingress.yaml: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress

We're running k8s 1.19 in GKE, meaning the Ingress object is deprecated in the v1beta1 namespace. It's been moved out of beta, and into the stable v1 API -- this PR updates the apiVersion to address this warning.