### PR TITLE
adds resource requests and limits to clinvar submitter

### DIFF
--- a/helm/values/clinvar-submitter/values-prod.yaml
+++ b/helm/values/clinvar-submitter/values-prod.yaml
@@ -7,3 +7,10 @@ image:
   pullPolicy: Always
   tag: "8ba1ab11d8eefa02b37f02f09057e72aaccbf6cd"
 scv_service_url: "https://us-central1-clingen-dx.cloudfunctions.net/ClinVarSCV"
+resources:
+  requests:
+    cpu: 500m
+    memory: 350Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi

--- a/helm/values/clinvar-submitter/values-stage.yaml
+++ b/helm/values/clinvar-submitter/values-stage.yaml
@@ -7,3 +7,10 @@ image:
   pullPolicy: Always
   tag: "8ba1ab11d8eefa02b37f02f09057e72aaccbf6cd"
 scv_service_url: "https://us-central1-clingen-stage.cloudfunctions.net/ClinVarSCV"
+resources:
+  requests:
+    cpu: 500m
+    memory: 350Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi


### PR DESCRIPTION
Closes #102 

This requests half a CPU core for clinvar submitter, and caps/limits it at a full core (we have 4 cores total on the GKE nodes). The historical CPU usage has been pretty negligible, so this feels a little generous, but figured allowing a core if nothing else is using it was reasonable.

Memory usage tends to hover between 250-275MBs over any given time. I set the request to 350MBs, with a hard limit of 1GB.