### PR TITLE
Iam role management

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,7 +2,8 @@
 
 This directory contains (or eventually will contain) the terraform definitions for the infrastructure behind various clingen components.
 
-- `modules/` - Contains reusable terraform modules. Appropriate for shared code between environments
+- `modules/` - Contains reusable terraform modules. Appropriate for shared components that are reused or repeated between environments
+- `shared/` - Configuration that is defined centrally for all environments. Appropriate for configs that are not necessarily reusable, but try to express identical configurations in all of det,stage, and prod.
 - `dev/` - development environment configs
 - `stage/` - staging environment configs
 - `prod/` - production environment configs

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -2,7 +2,7 @@
 module "clingen_projects_iam_bindings" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
   version = "7.2.0"
-  mode = "additive"
+  mode    = "additive"
 
   projects = ["clingen-dx", "clingen-stage", "clingen-dev"]
 
@@ -81,7 +81,7 @@ module "clingen_storage_readers_iam" {
 
   storage_buckets = ["clinvar-reports"]
 
-    bindings = {
+  bindings = {
     "roles/storage.objectViewer" = [
       "<clingen-data-viewers-tbd>@broadinstitute.org",
     ]

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -1,12 +1,15 @@
+# project-level permissions that need to be consistent across all three environments
 module "clingen_projects_iam_bindings" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
   version = "7.2.0"
+  mode = "additive"
 
   projects = ["clingen-dx", "clingen-stage", "clingen-dev"]
 
   bindings = {
     "roles/storage.admin" = [
       "group:clingendevs@broadinstitute.org",
+      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
     "roles/container.admin" = [
@@ -15,6 +18,7 @@ module "clingen_projects_iam_bindings" {
 
     "roles/compute.admin" = [
       "group:clingendevs@broadinstitute.org",
+      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
     "roles/appengine.appCreator" = [
@@ -26,43 +30,60 @@ module "clingen_projects_iam_bindings" {
     ]
 
     "roles/cloudfunctions.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/run.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/cloudscheduler.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/dns.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
+      "group:<collaborators-tbd>@broadinstitute.org",
+
     ]
 
     "roles/bigquery.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/monitoring.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/pubsub.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/firebase.admin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/cloudbuild.builds.editor" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/billing.viewer" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingendevs@broadinstitute.org",
+    ]
+  }
+}
+
+# grants for specific storage buckets
+module "clingen_storage_buckets_iam" {
+  source  = "terraform-google-modules/iam/google//modules/storage_buckets_iam"
+  version = "7.2.0"
+  mode    = "additive"
+
+  storage_buckets = ["clinvar-reports"]
+
+    bindings = {
+    "roles/storage.objectViewer" = [
+      "<clingen-data-viewers-tbd>@broadinstitute.org",
     ]
   }
 }

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -73,8 +73,8 @@ module "clingen_projects_iam_bindings" {
   }
 }
 
-# grants for specific storage buckets
-module "clingen_storage_buckets_iam" {
+# grants read access for specific storage buckets
+module "clingen_storage_readers_iam" {
   source  = "terraform-google-modules/iam/google//modules/storage_buckets_iam"
   version = "7.2.0"
   mode    = "additive"

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -7,9 +7,33 @@ module "clingen_projects_iam_bindings" {
   projects = ["clingen-dx", "clingen-stage", "clingen-dev"]
 
   bindings = {
-    "roles/storage.admin" = [
+
+    "roles/appengine.appAdmin" = [
       "group:clingendevs@broadinstitute.org",
-      "group:<collaborators-tbd>@broadinstitute.org",
+    ]
+
+    "roles/appengine.appCreator" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/bigquery.admin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/billing.viewer" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/cloudbuild.builds.editor" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/cloudfunctions.admin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/cloudscheduler.admin" = [
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/container.admin" = [
@@ -21,33 +45,13 @@ module "clingen_projects_iam_bindings" {
       "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
-    "roles/appengine.appCreator" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
-
-    "roles/appengine.appAdmin" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
-
-    "roles/cloudfunctions.admin" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
-
-    "roles/run.admin" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
-
-    "roles/cloudscheduler.admin" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
-
     "roles/dns.admin" = [
       "group:clingendevs@broadinstitute.org",
       "group:<collaborators-tbd>@broadinstitute.org",
 
     ]
 
-    "roles/bigquery.admin" = [
+    "roles/firebase.admin" = [
       "group:clingendevs@broadinstitute.org",
     ]
 
@@ -59,17 +63,15 @@ module "clingen_projects_iam_bindings" {
       "group:clingendevs@broadinstitute.org",
     ]
 
-    "roles/firebase.admin" = [
+    "roles/run.admin" = [
       "group:clingendevs@broadinstitute.org",
     ]
 
-    "roles/cloudbuild.builds.editor" = [
+    "roles/storage.admin" = [
       "group:clingendevs@broadinstitute.org",
+      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
-    "roles/billing.viewer" = [
-      "group:clingendevs@broadinstitute.org",
-    ]
   }
 }
 

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -48,7 +48,6 @@ module "clingen_projects_iam_bindings" {
     "roles/dns.admin" = [
       "group:clingendevs@broadinstitute.org",
       "group:<collaborators-tbd>@broadinstitute.org",
-
     ]
 
     "roles/firebase.admin" = [

--- a/terraform/dev/iam.tf
+++ b/terraform/dev/iam.tf
@@ -1,0 +1,68 @@
+module "clingen_projects_iam_bindings" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "7.2.0"
+
+  projects = ["clingen-dx", "clingen-stage", "clingen-dev"]
+
+  bindings = {
+    "roles/storage.admin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/container.admin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/compute.admin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/appengine.appCreator" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/appengine.appAdmin" = [
+      "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/cloudfunctions.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/run.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/cloudscheduler.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/dns.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/bigquery.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/monitoring.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/pubsub.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/firebase.admin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/cloudbuild.builds.editor" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/billing.viewer" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+  }
+}

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -24,10 +24,6 @@ module "clingen_projects_iam_bindings" {
       "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
-    "roles/billing.viewer" = [
-      "group:clingen-gcp-admin@broadinstitute.org",
-    ]
-
     "roles/cloudbuild.builds.editor" = [
       "group:clingen-gcp-admin@broadinstitute.org",
     ]
@@ -96,7 +92,7 @@ module "clingen_storage_readers_iam" {
 
   bindings = {
     "roles/storage.objectViewer" = [
-      "clingen-data-read@broadinstitute.org",
+      "group:clingen-data-read@broadinstitute.org",
     ]
   }
 }

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  region  = "us-east1"
+}
+
 # project-level permissions that need to be consistent across all three environments
 module "clingen_projects_iam_bindings" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
@@ -88,3 +92,4 @@ module "clingen_storage_readers_iam" {
     ]
   }
 }
+

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  region  = "us-east1"
+  region = "us-east1"
 }
 
 # project-level permissions that need to be consistent across all three environments
@@ -68,6 +68,14 @@ module "clingen_projects_iam_bindings" {
 
     "roles/run.admin" = [
       "group:clingendevs@broadinstitute.org",
+    ]
+
+    "roles/iam.serviceAccountAdmin" = [
+      "group:clingendevs@broadinstitute.org"
+    ]
+
+    "roles/serviceusage.apiKeysAdmin" = [
+      "group:clingendevs@broadinstitute.org"
     ]
 
     "roles/storage.admin" = [

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -13,74 +13,74 @@ module "clingen_projects_iam_bindings" {
   bindings = {
 
     "roles/appengine.appAdmin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/appengine.appCreator" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/bigquery.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/billing.viewer" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/cloudbuild.builds.editor" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/cloudfunctions.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/cloudscheduler.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/container.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/compute.admin" = [
+      "group:clingen-gcp-admin@broadinstitute.org",
       "group:clingendevs@broadinstitute.org",
-      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
     "roles/dns.admin" = [
+      "group:clingen-gcp-admin@broadinstitute.org",
       "group:clingendevs@broadinstitute.org",
-      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
     "roles/firebase.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/monitoring.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/pubsub.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/run.admin" = [
-      "group:clingendevs@broadinstitute.org",
+      "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
     "roles/iam.serviceAccountAdmin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingen-gcp-admin@broadinstitute.org"
     ]
 
     "roles/serviceusage.apiKeysAdmin" = [
-      "group:clingendevs@broadinstitute.org"
+      "group:clingen-gcp-admin@broadinstitute.org"
     ]
 
     "roles/storage.admin" = [
+      "group:clingen-gcp-admin@broadinstitute.org",
       "group:clingendevs@broadinstitute.org",
-      "group:<collaborators-tbd>@broadinstitute.org",
     ]
 
   }
@@ -96,7 +96,7 @@ module "clingen_storage_readers_iam" {
 
   bindings = {
     "roles/storage.objectViewer" = [
-      "<clingen-data-viewers-tbd>@broadinstitute.org",
+      "clingen-data-read@broadinstitute.org",
     ]
   }
 }

--- a/terraform/shared/iam/remote_state.tf
+++ b/terraform/shared/iam/remote_state.tf
@@ -1,13 +1,12 @@
 resource "google_storage_bucket_iam_member" "member" {
-  bucket  = "clingen-tfstate-shared"
-  role    = "roles/storage.objectAdmin"
-  member  = "group:clingendevs@broadinstitute.org"
-  project = "clingen-dx"
+  bucket = "clingen-tfstate-shared"
+  role   = "roles/storage.objectAdmin"
+  member = "group:clingendevs@broadinstitute.org"
 }
 
 terraform {
   backend "gcs" {
     bucket = "clingen-tfstate-shared"
-    prefix = "terraform/state"
+    prefix = "terraform/iam/state"
   }
 }

--- a/terraform/shared/iam/remote_state.tf
+++ b/terraform/shared/iam/remote_state.tf
@@ -1,0 +1,13 @@
+resource "google_storage_bucket_iam_member" "member" {
+  bucket  = "clingen-tfstate-shared"
+  role    = "roles/storage.objectAdmin"
+  member  = "group:clingendevs@broadinstitute.org"
+  project = "clingen-dx"
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "clingen-tfstate-shared"
+    prefix = "terraform/state"
+  }
+}


### PR DESCRIPTION
Hi all, looking for a review on the first pass here. Key notes:

- I'm utilizing the google-provided module for managing IAM roles: https://github.com/terraform-google-modules/terraform-google-iam. This module is designed to be used for enforcing the same IAM policies across several different GCP projects.
- Given that the module is managing resources in all three projects, I've introduced a "shared" namespace to our terraform directory, which is intended to be used for these higher-level cross-project settings.
  - the terraform state for this shared namespace will be kept in a clingen-tfstate-shared bucket, stored in the production GCP project.
- We have three google groups, which are the intended targets of these permission assignments, see #92 

The main goal here is to move IAM permissions from being granted directly to users, to granting them to groups instead. This eases management in the long run, and discourages bespoke sets of permissions that are difficult to replicate in the case that we add a new user later on.

Do folks generally feel OK with this approach?