### PR TITLE
Add Revision history limits to submitter and genegraph

### DIFF
--- a/helm/charts/clingen-clinvar-submitter/templates/deployment.yaml
+++ b/helm/charts/clingen-clinvar-submitter/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "clingen-clinvar-submitter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "clingen-clinvar-submitter.selectorLabels" . | nindent 6 }}

--- a/helm/charts/clingen-clinvar-submitter/values.yaml
+++ b/helm/charts/clingen-clinvar-submitter/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 3
+
 image:
   repository: gcr.io/clingen-stage/clinvar-submitter
   pullPolicy: Always

--- a/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "clingen-genegraph.chartLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.genegraph_replicas }}
+  revisionHistoryLimit: {{ .Values.genegraph_revisionhistorylimit }}
   {{- with .Values.genegraph_update_strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -2,6 +2,7 @@
 
 # deployment
 genegraph_replicas: 1
+genegraph_revisionhistorylimit: 3
 genegraph_update_strategy: {}
 genegraph_pod_affinity: {}
 genegraph_docker_image_name: gcr.io/clingen-dev/genegraph


### PR DESCRIPTION
Closes #99 

By default, kubernetes keeps 10 old revisions of every Deployment object. With a lot of deployments, this can cause performance issues on the kubernetes API service, so it's recommended that we set a smaller number. 

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy

This PR sets the spec.revisionHistoryLimit on the clinvar submitter and genegraph deployments, using a default value of 3.