### PR TITLE
update to implementationspecific pathType to appease google

### DIFF
--- a/helm/charts/clingen-argocd/Chart.lock
+++ b/helm/charts/clingen-argocd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 3.6.8
-digest: sha256:2b8e16280e1f1e9d99c055a069ccda2a1c8bc90686b62c41fa2f74af23c4cdf0
-generated: "2021-06-17T11:50:36.864168-04:00"
+  version: 3.11.1
+digest: sha256:b50a3d1567907b50798d937d71ef62cf28f7e4685b6d4c9bc5c81b3931aedd0e
+generated: "2021-08-02T10:00:24.640224-04:00"

--- a/helm/charts/clingen-argocd/Chart.yaml
+++ b/helm/charts/clingen-argocd/Chart.yaml
@@ -3,5 +3,5 @@ name: clingen-argocd
 version: 1.0.0
 dependencies:
   - name: argo-cd
-    version: 3.6.8
+    version: 3.11.1
     repository: https://argoproj.github.io/argo-helm

--- a/helm/charts/clingen-argocd/values.yaml
+++ b/helm/charts/clingen-argocd/values.yaml
@@ -23,6 +23,7 @@ argo-cd:
       enabled: true
       paths:
         - /*
+      pathType: ImplementationSpecific
       hosts:
         - *argohost
       annotations:

--- a/helm/charts/clingen-clinvar-submitter/templates/ingress.yaml
+++ b/helm/charts/clingen-clinvar-submitter/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
       http:
         paths:
           - path: /*
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ include "clingen-clinvar-submitter.fullname" . }}

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint --with-subcharts=false charts/$chart
-        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose -kubernetes-version "1.19.9"
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig" -verbose -kubernetes-version "1.20.8"
       done
 
 # timeout if not complete in 10 minutes


### PR DESCRIPTION
It looks like google updated Kubernetes this weekend, and now `Prefix` is an unsupported pathType, and we need to use `implementationSpecific`. Still testing this, but I think these changes are what we need.