### PR TITLE
adds a pull request check to clinvar-submitter

### DIFF
--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -15,7 +15,7 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
 }
 
 # clinvar-submitter pull request checks
-resource "google_cloudbuild_trigger" "architecture_helm_lint" {
+resource "google_cloudbuild_trigger" "clinvar_submitter_pr" {
   name        = "clinvar-submitter-pull-request"
   description = "checks to perform on pull requests in the clinvar-submitter"
 

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -11,7 +11,7 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
     }
   }
 
-  filename = "cloudbuild.yaml"
+  filename = ".cloudbuild/docker-build.cloudbuild.yaml"
 }
 
 # clinvar-submitter pull request checks

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -14,6 +14,22 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
   filename = "cloudbuild.yaml"
 }
 
+# clinvar-submitter pull request checks
+resource "google_cloudbuild_trigger" "architecture_helm_lint" {
+  name        = "clinvar-submitter-pull-request"
+  description = "checks to perform on pull requests in the clinvar-submitter"
+
+  github {
+    name  = "clinvar-submitter"
+    owner = "clingen-data-model"
+    pull_request {
+      branch = "^master$"
+    }
+  }
+
+  filename = ".cloudbuild/pull-request.cloudbuild.yaml"
+}
+
 # architecture helm chart linting
 resource "google_cloudbuild_trigger" "architecture_helm_lint" {
   name        = "architecture-helm-pr-lint"


### PR DESCRIPTION
Our current build trigger in the submitter is intended for post-merge events, where we start triggering deployment. This change adds a cloudbuild step that runs on PRs, which is intended for linting and lightweight unit tests that we'd like to happen when PRs are opened, before merge.

This change is coupled with https://github.com/clingen-data-model/clinvar-submitter/pull/15