### PR TITLE
vendor our own cloudarmor module

### DIFF
--- a/helm/charts/clingen-argocd/templates/argocd-backendconfig.yaml
+++ b/helm/charts/clingen-argocd/templates/argocd-backendconfig.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name }}
 spec:
   securityPolicy:
-    name: "broad-cloud-armor"
+    name: "clingen-argo-cloudarmor"

--- a/helm/charts/clingen-argocd/templates/argocd-backendconfig.yaml
+++ b/helm/charts/clingen-argocd/templates/argocd-backendconfig.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name }}
 spec:
   securityPolicy:
-    name: "clingen-argo-cloudarmor"
+    name: "clingen-argo-cloud-armor"

--- a/terraform/prod/argo.tf
+++ b/terraform/prod/argo.tf
@@ -6,6 +6,7 @@ module "broad_cloudarmor_policy" {
 resource "google_compute_security_policy" "argocd_cloudarmor_policy" {
   name = "clingen-argo-cloud-armor"
 
+  # subnets for the Broad
   # only 5 cidrs allowed per rule
   rule {
     action   = "allow"
@@ -58,6 +59,22 @@ resource "google_compute_security_policy" "argocd_cloudarmor_policy" {
           "69.173.64.0/19",
           "69.173.127.192/27",
           "69.173.124.0/23"
+        ]
+      }
+    }
+  }
+
+  # external collaborator subnets
+  rule {
+    action   = "allow"
+    priority = "3"
+
+    match {
+      versioned_expr = "SRC_IPS_V1"
+
+      config {
+        src_ip_ranges = [
+          "74.69.78.31/32"
         ]
       }
     }

--- a/terraform/prod/argo.tf
+++ b/terraform/prod/argo.tf
@@ -1,8 +1,4 @@
-module "broad_cloudarmor_policy" {
-  source = "github.com/broadinstitute/terraform-shared//terraform-modules/cloud-armor-rule?ref=71303ce4f7d1249657ebe404059b0aea52523748"
-}
-
-
+# Cloudarmor policy for restricting access to the argo web UI
 resource "google_compute_security_policy" "argocd_cloudarmor_policy" {
   name = "clingen-argo-cloud-armor"
 

--- a/terraform/prod/argo.tf
+++ b/terraform/prod/argo.tf
@@ -1,3 +1,79 @@
 module "broad_cloudarmor_policy" {
   source = "github.com/broadinstitute/terraform-shared//terraform-modules/cloud-armor-rule?ref=71303ce4f7d1249657ebe404059b0aea52523748"
 }
+
+
+resource "google_compute_security_policy" "argocd_cloudarmor_policy" {
+  name = "clingen-argo-cloud-armor"
+
+  # only 5 cidrs allowed per rule
+  rule {
+    action   = "allow"
+    priority = "0"
+
+    match {
+      versioned_expr = "SRC_IPS_V1"
+
+      config {
+        src_ip_ranges = [
+          "69.173.112.0/21",
+          "69.173.127.232/29",
+          "69.173.127.128/26",
+          "69.173.127.0/25",
+          "69.173.127.240/28"
+        ]
+      }
+    }
+  }
+  # only 5 cidrs allowed per rule
+  rule {
+    action   = "allow"
+    priority = "1"
+
+    match {
+      versioned_expr = "SRC_IPS_V1"
+
+      config {
+        src_ip_ranges = [
+          "69.173.127.224/30",
+          "69.173.127.230/31",
+          "69.173.120.0/22",
+          "69.173.127.228/32",
+          "69.173.126.0/24"
+        ]
+      }
+    }
+  }
+  # only 5 cidrs allowed per rule
+  rule {
+    action   = "allow"
+    priority = "2"
+
+    match {
+      versioned_expr = "SRC_IPS_V1"
+
+      config {
+        src_ip_ranges = [
+          "69.173.96.0/20",
+          "69.173.64.0/19",
+          "69.173.127.192/27",
+          "69.173.124.0/23"
+        ]
+      }
+    }
+  }
+
+  rule {
+    action      = "deny(403)"
+    priority    = "2147483647"
+    description = "Default rule: deny all"
+
+    match {
+      versioned_expr = "SRC_IPS_V1"
+
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The broad cloudarmor module has been working fine, but it's not written in a way that will let us extend it to add non-broad collaborator networks to our policies. I've decided to vendor it ourselves instead so that we can add our own networks.

Since I only really see this being used in Argo, I haven't modularized it. Another much more complicated approach would be to create a module that allows dynamic `rule {}` creation with [nested dynamic blocks](https://www.terraform.io/docs/language/expressions/dynamic-blocks.html#multi-level-nested-block-structures), but I I don't see all that much value in doing so.

Closes #118 