### PR TITLE
Lock the terraform version

### DIFF
--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -7,6 +7,8 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
+  required_version = ">= 1.0.0, < 1.1.0"
+
   backend "gcs" {
     bucket = "clingen-tfstate-dev"
     prefix = "terraform/state"

--- a/terraform/prod/remote_state.tf
+++ b/terraform/prod/remote_state.tf
@@ -7,6 +7,8 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
+  required_version = ">= 1.0.0, < 1.1.0"
+
   backend "gcs" {
     bucket = "clingen-tfstate-prod"
     prefix = "terraform/state"

--- a/terraform/shared/iam/remote_state.tf
+++ b/terraform/shared/iam/remote_state.tf
@@ -5,6 +5,8 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
+  required_version = ">= 1.0.0, < 1.1.0"
+
   backend "gcs" {
     bucket = "clingen-tfstate-shared"
     prefix = "terraform/iam/state"

--- a/terraform/stage/remote_state.tf
+++ b/terraform/stage/remote_state.tf
@@ -7,6 +7,8 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
+  required_version = ">= 1.0.0, < 1.1.0"
+
   backend "gcs" {
     bucket = "clingen-tfstate-stage"
     prefix = "terraform/state"


### PR DESCRIPTION
As we start collaborating on terraform code a little more, it's a good idea to add a version constraint to enforce which versions of terraform that we're using. This is important, since terraform just crossed a major semver (1.0.0) boundary, and some syntax that we're using may not be compatible with older versions of terraform.

This constraint denotes that we should be using at least version 1.0.0, and anything less than 1.1.0. If you're outside of these boundaries, you'll get an error indicating that you need to install a compatible terraform release.