### PR TITLE
Remove default notification subs, add per-project subscriptions

### DIFF
--- a/helm/values/argocd-notifications/values-prod.yaml
+++ b/helm/values/argocd-notifications/values-prod.yaml
@@ -2,15 +2,6 @@ argocdUrl: "https://argocd.prod.clingen.app"
 logLevel: warn
 secret:
   create: false
-subscriptions:
-  - recipients:
-    - slack:clingen-deploy
-    triggers:
-      - on-sync-status-unknown
-      - on-health-degraded
-      - on-sync-failed
-      - on-sync-running
-      - on-sync-succeeded
 triggers:
   trigger.on-health-degraded: |
     - description: Application has degraded

--- a/services/dev/argo/dev-app-project.yaml
+++ b/services/dev/argo/dev-app-project.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  creationTimestamp: "2021-04-12T20:04:25Z"
+  generation: 4
+  name: dev
+  namespace: argocd
+  resourceVersion: "185370900"
+  uid: b42a4e8a-0dbc-490b-9d66-ca47aedc1f5b
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  description: development environment
+  destinations:
+  - namespace: '*'
+    server: https://35.237.22.18
+  sourceRepos:
+  - https://github.com/clingen-data-model/architecture.git

--- a/services/prod/argo/prod-app-project.yaml
+++ b/services/prod/argo/prod-app-project.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-running.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: clingen-deploy
+  creationTimestamp: "2021-04-12T20:06:30Z"
+  generation: 4
+  name: prod
+  namespace: argocd
+  resourceVersion: "185367753"
+  uid: 8f6e020f-308b-4776-8830-5d575ff8e670
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  description: production environment
+  destinations:
+  - namespace: '*'
+    server: https://kubernetes.default.svc
+  sourceRepos:
+  - https://github.com/clingen-data-model/architecture.git

--- a/services/stage/argo/stage-app-project.yaml
+++ b/services/stage/argo/stage-app-project.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-running.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: clingen-deploy
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: clingen-deploy
+  creationTimestamp: "2021-04-12T20:05:59Z"
+  generation: 4
+  name: stage
+  namespace: argocd
+  resourceVersion: "185367585"
+  uid: 8e58b052-d3e3-438e-ace9-a2eddcaa1567
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  description: staging environment
+  destinations:
+  - namespace: '*'
+    server: https://35.185.65.146
+  sourceRepos:
+  - https://github.com/clingen-data-model/architecture.git


### PR DESCRIPTION
We initially configured argocd-notifications to automatically send deployment notifications for every managed app. This proved to be a little annoying for some of the more iterative development deployments. This change removes the default subscriptions, and sets the subscriptions by project now (apps/deployments in argo are grouped into projects, which are one of dev, stage, or prod in our case).

The settings should now have all alert subscriptions for applications in stage and prod, and no notifications for dev.

If in the future you would like to enable notifications for just a single application in dev, you can add the same annotations that I put on the projects -- you simply put them on the argo Application manifest instead. See : https://argocd-notifications.readthedocs.io/en/stable/subscriptions/ for more info.

Closes #131 