### PR TITLE
add resource requests and limits to the argocd components

### DIFF
--- a/helm/charts/clingen-argocd/values.yaml
+++ b/helm/charts/clingen-argocd/values.yaml
@@ -9,10 +9,47 @@ argo-cd:
   controller:
     logLevel: warn
     logFormat: json
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "384Mi"
+  dex:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "300m"
+        memory: "128Mi"
+  redis:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "300m"
+        memory: "128Mi"
   repoServer:
     logLevel: warn
     logFormat: json
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "300m"
+        memory: "128Mi"
   server:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
     logLevel: warn
     logFormat: json
     service:


### PR DESCRIPTION
the defaults for the argo-cd helm chart are to run the argo components without requests and limits. This PR adds values for those, to ensure that argo can't run away with all of the cluster resources.

Closes #144