### PR TITLE
add clingen-data-read as project-level bigquery viewers

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -101,11 +101,6 @@ resource "google_project_iam_member" "clingen_bigquery_prod_readers" {
   project = "clingen-dx"
   role    = "roles/bigquery.dataViewer"
   member  = "group:clingen-data-read@broadinstitute.org"
-
-  condition {
-    title      = "dataset_startswith_clinvar"
-    expression = "resource.name.startsWith(\"/projects/clingen-dx/datasets/clinvar_\")"
-  }
 }
 
 resource "google_project_iam_member" "clingen_bigquery_dev_readers" {
@@ -113,8 +108,4 @@ resource "google_project_iam_member" "clingen_bigquery_dev_readers" {
   role    = "roles/bigquery.dataViewer"
   member  = "group:clingen-data-read@broadinstitute.org"
 
-  condition {
-    title      = "dataset_startswith_clinvar"
-    expression = "resource.name.startsWith(\"/projects/clingen-dev/datasets/clinvar_\")"
-  }
 }

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -101,10 +101,20 @@ resource "google_project_iam_member" "clingen_bigquery_prod_readers" {
   project = "clingen-dx"
   role    = "roles/bigquery.dataViewer"
   member  = "group:clingen-data-read@broadinstitute.org"
+
+  condition {
+    title      = "dataset_startswith_clinvar"
+    expression = "resource.name.startsWith(\"/projects/clingen-dx/datasets/clinvar_\")"
+  }
 }
 
 resource "google_project_iam_member" "clingen_bigquery_dev_readers" {
   project = "clingen-dev"
   role    = "roles/bigquery.dataViewer"
   member  = "group:clingen-data-read@broadinstitute.org"
+
+  condition {
+    title      = "dataset_startswith_clinvar"
+    expression = "resource.name.startsWith(\"/projects/clingen-dev/datasets/clinvar_\")"
+  }
 }

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -97,3 +97,14 @@ module "clingen_storage_readers_iam" {
   }
 }
 
+resource "google_project_iam_member" "clingen_bigquery_prod_readers" {
+  project = "clingen-dx"
+  role    = "roles/bigquery.dataViewer"
+  member  = "group:clingen-data-read@broadinstitute.org"
+}
+
+resource "google_project_iam_member" "clingen_bigquery_dev_readers" {
+  project = "clingen-dev"
+  role    = "roles/bigquery.dataViewer"
+  member  = "group:clingen-data-read@broadinstitute.org"
+}


### PR DESCRIPTION
This adds the clingen-data-read google group as project-level bigquery dataViewers, with the one condition that they are only allowed to view datasets that start with "clinvar_". If this is too narrow, we can extend the condition. I've applied this as-is, so folks should test, and we can update/merge once everything looks good.

cc @larrybabb 