### PR TITLE
Add mondo notifier cloudfunction

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -121,3 +121,17 @@ resource "google_project_iam_member" "clingen_bigquery_dev_cxn_users" {
   role    = "roles/bigquery.jobUser"
   member  = "group:clingen-data-read@broadinstitute.org"
 }
+
+resource "google_project_iam_custom_role" "cloudfunction_unauthed_perms" {
+  project     = "clingen-dx"
+  role_id     = "cloudbuildFunctionIamManager"
+  title       = "IAM Policy Manager for CloudFunctions"
+  description = "Allows for updating the IAM policy on cloudfunctions to enable unauthenticated functions"
+  permissions = ["cloudfunctions.functions.setIamPolicy", "cloudfunctions.functions.getIamPolicy"]
+}
+
+resource "google_project_iam_member" "cloudbuild_iam_manager" {
+  project = "clingen-dx"
+  role    = google_project_iam_custom_role.cloudfunction_unauthed_perms.name
+  member  = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}

--- a/terraform/shared/mondo_notifier/main.tf
+++ b/terraform/shared/mondo_notifier/main.tf
@@ -1,0 +1,47 @@
+provider "google" {
+  region  = "us-east1"
+  project = "clingen-dx"
+}
+
+resource "google_service_account" "mondo_notifier_func" {
+  account_id   = "clingen-mondo-notify"
+  display_name = "Cloud function for notifying on new mondo releases"
+}
+
+resource "google_pubsub_topic" "mondo_notifications" {
+  name = "mondo-release-notifications"
+
+  labels = {
+    managed_by   = "terraform"
+    owner        = "sjahl"
+    pubsub_topic = "mondo-release-notifications"
+  }
+}
+
+resource "google_pubsub_topic_iam_member" "mondo_function" {
+  topic  = google_pubsub_topic.mondo_notifications.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.mondo_notifier_func.email}"
+}
+
+# allows for automated cloudbuild deployments
+resource "google_service_account_iam_member" "cloudbuild_mondo_notifier_binding" {
+  service_account_id = "projects/clingen-dx/serviceAccounts/${google_service_account.mondo_notifier_func.email}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_cloudbuild_trigger" "mondo_notifier_repo" {
+  name        = "mondo-notifier-push"
+  description = "Redeploy mondo notifier function on push to main"
+
+  github {
+    name  = "mondo-notifier"
+    owner = "clingen-data-model"
+    push {
+      branch = "^main$"
+    }
+  }
+
+  filename = "cloudbuild.yaml"
+}

--- a/terraform/shared/mondo_notifier/main.tf
+++ b/terraform/shared/mondo_notifier/main.tf
@@ -13,10 +13,14 @@ resource "google_service_account" "confluent_cloud_pubsub_subscriber" {
   display_name = "Subscriber account for consuming mondo update notifications"
 }
 
-resource "google_pubsub_subscription_iam_member" "confluent_dev_binding" {
-  subscription = google_pubsub_subscription.kafka_source_subscription.name
-  role         = "roles/pubsub.subscriber"
-  member       = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+resource "google_project_iam_member" "confluent_dev_binding" {
+  role   = "roles/pubsub.subscriber"
+  member = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+}
+
+resource "google_project_iam_member" "confluent_dev_viewer_binding" {
+  role   = "roles/pubsub.viewer"
+  member = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
 }
 
 resource "google_pubsub_topic" "mondo_notifications" {

--- a/terraform/shared/mondo_notifier/outputs.tf
+++ b/terraform/shared/mondo_notifier/outputs.tf
@@ -1,0 +1,3 @@
+output "mondo_notifier_service_account" {
+  value = google_service_account.mondo_notifier_func.email
+}

--- a/terraform/shared/mondo_notifier/remote_state.tf
+++ b/terraform/shared/mondo_notifier/remote_state.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.0.0, < 1.1.0"
+
+  backend "gcs" {
+    bucket = "clingen-tfstate-shared"
+    prefix = "terraform/mondo_notifier/state"
+  }
+}


### PR DESCRIPTION
Configures:
- a service account for the mondo function to run as
- cloudbuild perms for auto-deploying the mondo function
- a pubsub queue that will be the destination for upgrade notifications
- a cloudbuild trigger that updates the function in GCP when the https://github.com/clingen-data-model/mondo-notifier repo is updated.

The function doesn't do anything yet, but it can be invoked at https://us-east1-clingen-dx.cloudfunctions.net/mondo-notifier

Eventually the goal is for the function to receive a webhook notification from mondo, and then send the relevant information in a pubsub message, which kafka will be able to consume via the [Confluent PubSub Source connector](https://docs.confluent.io/cloud/current/connectors/cc-google-pubsub-source.html)

Touches: https://github.com/clingen-data-model/data-exchange-topics/issues/15