### PR TITLE
Adding batch for gene-dosage-restored for genegraph

### DIFF
--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -29,7 +29,7 @@ genegraph_liveness_probe:
   httpGet:
     path: /live
     port: genegraph-port
-genegraph_batch_event_sources: gci-express-json;gci-neo4j-archive
+genegraph_batch_event_sources: gci-express-json;gci-neo4j-archive;gene-dosage-restored
 
 # certificate and ingress
 genegraph_configure_ingress: true 


### PR DESCRIPTION
In anticipation of a Genegraph PR, adding a new batch format to the standard Genegraph build