### PR TITLE
Upgrade google terraform provider to 4.3.0

### DIFF
--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "google" {
     enabled = true
-    version = "0.11.0"
+    version = "0.15.0"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -6,8 +6,9 @@ provider "google" {
 data "google_project" "current" {}
 
 module "external-secrets" {
-  source = "../modules/external-secrets"
-  env    = "dev"
+  source     = "../modules/external-secrets"
+  env        = "dev"
+  project_id = data.google_project.current.project_id
 }
 
 module "cloudbuild-firebase" {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -3,6 +3,8 @@ provider "google" {
   region  = "us-east1"
 }
 
+data "google_project" "current" {}
+
 module "external-secrets" {
   source = "../modules/external-secrets"
   env    = "dev"
@@ -10,7 +12,8 @@ module "external-secrets" {
 
 module "cloudbuild-firebase" {
   source            = "../modules/cloudbuild-firebase"
-  project_id_number = "522856288592"
+  project_id_number = data.google_project.current.number
+  project_id        = data.google_project.current.project_id
 }
 
 module "dev-gke-cluster" {

--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -8,6 +8,12 @@ resource "google_storage_bucket_iam_member" "member" {
 
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
 
   backend "gcs" {
     bucket = "clingen-tfstate-dev"

--- a/terraform/modules/cloudbuild-firebase/main.tf
+++ b/terraform/modules/cloudbuild-firebase/main.tf
@@ -1,10 +1,20 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
+}
 # Grant the firebase roles to the cloudbuild serviceaccount
 resource "google_project_iam_member" "cloudbuild_firebase_binding" {
-  role   = "roles/firebase.admin"
-  member = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
+  role    = "roles/firebase.admin"
+  member  = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
+  project = var.project_id
 }
 
 resource "google_project_iam_member" "cloudbuild_apikeys_binding" {
-  role   = "roles/serviceusage.apiKeysAdmin"
-  member = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
+  role    = "roles/serviceusage.apiKeysAdmin"
+  member  = "serviceAccount:${var.project_id_number}@cloudbuild.gserviceaccount.com"
+  project = var.project_id
 }

--- a/terraform/modules/cloudbuild-firebase/variables.tf
+++ b/terraform/modules/cloudbuild-firebase/variables.tf
@@ -1,4 +1,9 @@
 variable "project_id_number" {
   type        = string
-  description = "The project number prefix of the default service accounts"
+  description = "The project number prefix of the default service accounts."
+}
+
+variable "project_id" {
+  type = string
+  description = "The project ID to create the IAM resources in. Required as of google provider version 4.0"
 }

--- a/terraform/modules/external-secrets/main.tf
+++ b/terraform/modules/external-secrets/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
+}
+
 # The IAM role that we'll use to allow read access to all GCP secrets within the project
 resource "google_project_iam_custom_role" "external-secrets-gsa" {
   role_id     = "clingen_${var.env}_external_secrets"
@@ -24,8 +33,9 @@ resource "google_service_account" "clingen-external-secrets" {
 
 # Bind the ServiceAccount to the IAM role.
 resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
-  role   = google_project_iam_custom_role.external-secrets-gsa.name
-  member = "serviceAccount:${google_service_account.clingen-external-secrets.email}"
+  role    = google_project_iam_custom_role.external-secrets-gsa.name
+  member  = "serviceAccount:${google_service_account.clingen-external-secrets.email}"
+  project = var.project_id
 }
 
 # Generate a key for the ServiceAccount, for the controller to authenticate with

--- a/terraform/modules/external-secrets/variables.tf
+++ b/terraform/modules/external-secrets/variables.tf
@@ -2,3 +2,8 @@ variable "env" {
   type        = string
   description = "The name of the environment we are deploying to. E.g. {dev,stage,prod}"
 }
+
+variable "project_id" {
+  type = string
+  description = "A string containing the name of the project to create IAM resources in. Required as of google provider version 4.0"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -3,9 +3,12 @@ provider "google" {
   region  = "us-east1"
 }
 
+data "google_project" "current" {}
+
 module "external-secrets" {
-  source = "../modules/external-secrets"
-  env    = "prod"
+  source     = "../modules/external-secrets"
+  env        = "prod"
+  project_id = data.google_project.current.project_id
 }
 
 module "prod-gke-cluster" {
@@ -36,8 +39,9 @@ resource "google_service_account_iam_member" "cloudbuild_appspot_binding" {
 }
 
 resource "google_project_iam_member" "cloudbuild_cloudfunctions_grant" {
-  role   = "roles/cloudfunctions.developer"
-  member = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+  project = data.google_project.current.project_id
 }
 
 # IAM binding for allowing staging clinvarSCV function to run prod bigquery

--- a/terraform/prod/remote_state.tf
+++ b/terraform/prod/remote_state.tf
@@ -1,13 +1,20 @@
 # configs for managing access to the terraform state bucket
 
 resource "google_storage_bucket_iam_member" "member" {
-  bucket = "clingen-tfstate-prod"
-  role   = "roles/storage.objectAdmin"
-  member = "group:clingendevs@broadinstitute.org"
+  bucket  = "clingen-tfstate-prod"
+  role    = "roles/storage.objectAdmin"
+  member  = "group:clingendevs@broadinstitute.org"
 }
 
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
+
 
   backend "gcs" {
     bucket = "clingen-tfstate-prod"

--- a/terraform/shared/clinvar_sync_cron/main.tf
+++ b/terraform/shared/clinvar_sync_cron/main.tf
@@ -3,13 +3,15 @@ provider "google" {
   project = "clingen-stage"
 }
 
+data "google_project" "current" {}
+
 resource "google_service_account" "clinvar_bigquery_updater" {
   account_id   = "clinvar-bq-updater"
   display_name = "Cron Job for updating clinvar ingest data"
 }
 
 resource "google_project_iam_binding" "project" {
-  project = "clingen-stage"
+  project = data.google_project.current.project_id
   role    = "roles/bigquery.dataEditor"
 
   members = [
@@ -18,7 +20,7 @@ resource "google_project_iam_binding" "project" {
 }
 
 resource "google_project_iam_binding" "bq_jobuser" {
-  project = "clingen-stage"
+  project = data.google_project.current.project_id
   role    = "roles/bigquery.jobUser"
 
   members = [

--- a/terraform/shared/clinvar_sync_cron/remote_state.tf
+++ b/terraform/shared/clinvar_sync_cron/remote_state.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
 
   backend "gcs" {
     bucket = "clingen-tfstate-shared"

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -5,7 +5,7 @@ provider "google" {
 # project-level permissions that need to be consistent across all three environments
 module "clingen_projects_iam_bindings" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
-  version = "7.2.0"
+  version = "7.4.0"
   mode    = "additive"
 
   projects = ["clingen-dx", "clingen-stage", "clingen-dev"]
@@ -85,7 +85,7 @@ module "clingen_projects_iam_bindings" {
 # grants read access for specific storage buckets
 module "clingen_storage_readers_iam" {
   source  = "terraform-google-modules/iam/google//modules/storage_buckets_iam"
-  version = "7.2.0"
+  version = "7.4.0"
   mode    = "additive"
 
   storage_buckets = ["clinvar-reports"]

--- a/terraform/shared/iam/remote_state.tf
+++ b/terraform/shared/iam/remote_state.tf
@@ -6,6 +6,12 @@ resource "google_storage_bucket_iam_member" "member" {
 
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
 
   backend "gcs" {
     bucket = "clingen-tfstate-shared"

--- a/terraform/shared/kafka_backups/remote_state.tf
+++ b/terraform/shared/kafka_backups/remote_state.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
 
   backend "gcs" {
     bucket = "clingen-tfstate-shared"

--- a/terraform/shared/mondo_notifier/main.tf
+++ b/terraform/shared/mondo_notifier/main.tf
@@ -3,6 +3,8 @@ provider "google" {
   project = "clingen-dx"
 }
 
+data "google_project" "current" {}
+
 resource "google_service_account" "mondo_notifier_func" {
   account_id   = "clingen-mondo-notify"
   display_name = "Cloud function for notifying on new mondo releases"
@@ -14,13 +16,15 @@ resource "google_service_account" "confluent_cloud_pubsub_subscriber" {
 }
 
 resource "google_project_iam_member" "confluent_dev_binding" {
-  role   = "roles/pubsub.subscriber"
-  member = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+  project = data.google_project.current.project_id
 }
 
 resource "google_project_iam_member" "confluent_dev_viewer_binding" {
-  role   = "roles/pubsub.viewer"
-  member = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+  role    = "roles/pubsub.viewer"
+  member  = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
+  project = data.google_project.current.project_id
 }
 
 resource "google_pubsub_topic" "mondo_notifications" {

--- a/terraform/shared/mondo_notifier/remote_state.tf
+++ b/terraform/shared/mondo_notifier/remote_state.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
 
   backend "gcs" {
     bucket = "clingen-tfstate-shared"

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -3,14 +3,18 @@ provider "google" {
   region  = "us-east1"
 }
 
+data "google_project" "current" {}
+
 module "cloudbuild-firebase" {
   source            = "../modules/cloudbuild-firebase"
-  project_id_number = "583560269534"
+  project_id_number = data.google_project.current.number
+  project_id        = data.google_project.current.project_id
 }
 
 module "external-secrets" {
-  source = "../modules/external-secrets"
-  env    = "stage"
+  source     = "../modules/external-secrets"
+  env        = "stage"
+  project_id = data.google_project.current.project_id
 }
 
 module "stage-gke-cluster" {

--- a/terraform/stage/remote_state.tf
+++ b/terraform/stage/remote_state.tf
@@ -8,6 +8,13 @@ resource "google_storage_bucket_iam_member" "member" {
 
 terraform {
   required_version = ">= 1.0.0, < 1.1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.3.0"
+    }
+  }
+
 
   backend "gcs" {
     bucket = "clingen-tfstate-stage"


### PR DESCRIPTION
I noticed our terraform google provider was a major version out of date. This PR adds version constraints to the provider configuration, and adds required changes to make our config compatible with the new version. The changes here all result in a `No changes. Your infrastructure matches the configuration.` from a terraform plan.

The first time you encounter the updated code during a terraform apply, you may need to run a `terraform init -upgrade` to have terraform download the new plugin versions.