### PR TITLE
Turning off resolver cache in stage to test performance

### DIFF
--- a/helm/values/genegraph/values-stage.yaml
+++ b/helm/values/genegraph/values-stage.yaml
@@ -35,4 +35,4 @@ genegraph_mcrt_domains:
 genegraph_static_ip_name: clingen-ds-stage-ip
 # run migration job before deployment
 genegraph_run_migration: true
-
+genegraph_gql_cache: false


### PR DESCRIPTION
As above; this setting may no longer be needed to offer adequate performance, and has been something of a headache since its inception.