### PR TITLE
adds a timeout of 20 minutes to the genegraph service

### DIFF
--- a/helm/charts/clingen-genegraph/templates/genegraph-backendconfig.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-backendconfig.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.genegraph_configure_ingress }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ .Release.Name }}-backendconfig
+spec:
+  timeoutSec: 1200
+{{- end }}

--- a/helm/charts/clingen-genegraph/templates/genegraph-service.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
+  annotations:
+    {{- if .Values.genegraph_configure_ingress }}
+    cloud.google.com/backend-config: '{"default": "{{ .Release.Name }}-backendconfig"}'
+    {{- end }}
   labels:
     app: {{ .Release.Name }}
 {{ include "clingen-genegraph.labels" . | indent 4 }}


### PR DESCRIPTION
I think this is what is required to allow a 20 minute timeout for genegraph as described in standup.

We create a BackendConfig resource, and then in the Service resource, we add an annotation to associate it with the backend config.