### PR TITLE
update terraform version reqs to allow newer versions

### DIFF
--- a/terraform/dev/remote_state.tf
+++ b/terraform/dev/remote_state.tf
@@ -7,7 +7,7 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/prod/remote_state.tf
+++ b/terraform/prod/remote_state.tf
@@ -7,7 +7,7 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/shared/clinvar_sync_cron/remote_state.tf
+++ b/terraform/shared/clinvar_sync_cron/remote_state.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/shared/iam/remote_state.tf
+++ b/terraform/shared/iam/remote_state.tf
@@ -5,7 +5,7 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/shared/kafka_backups/remote_state.tf
+++ b/terraform/shared/kafka_backups/remote_state.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/shared/mondo_notifier/remote_state.tf
+++ b/terraform/shared/mondo_notifier/remote_state.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/stage/remote_state.tf
+++ b/terraform/stage/remote_state.tf
@@ -7,7 +7,7 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 terraform {
-  required_version = ">= 1.0.0, < 1.1.0"
+  required_version = ">= 1.0.0, < 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Looking for more of a rubber stamp of approval here -- no real changes, just allowing newer versions of the terraform cli to operate on our infra. Applying this results in "No changes" to existing infra.