### PR TITLE
remove the pubsub infra from the mondo notifier

### DIFF
--- a/terraform/shared/mondo_notifier/main.tf
+++ b/terraform/shared/mondo_notifier/main.tf
@@ -10,59 +10,6 @@ resource "google_service_account" "mondo_notifier_func" {
   display_name = "Cloud function for notifying on new mondo releases"
 }
 
-resource "google_service_account" "confluent_cloud_pubsub_subscriber" {
-  account_id   = "clingen-dev-mondo-subscriber"
-  display_name = "Subscriber account for consuming mondo update notifications"
-}
-
-resource "google_project_iam_member" "confluent_dev_binding" {
-  role    = "roles/pubsub.subscriber"
-  member  = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
-  project = data.google_project.current.project_id
-}
-
-resource "google_project_iam_member" "confluent_dev_viewer_binding" {
-  role    = "roles/pubsub.viewer"
-  member  = "serviceAccount:${google_service_account.confluent_cloud_pubsub_subscriber.email}"
-  project = data.google_project.current.project_id
-}
-
-resource "google_pubsub_topic" "mondo_notifications" {
-  name = "mondo-release-notifications"
-
-  labels = {
-    managed_by   = "terraform"
-    owner        = "sjahl"
-    pubsub_topic = "mondo-release-notifications"
-  }
-}
-
-resource "google_pubsub_subscription" "kafka_source_subscription" {
-  name  = "confluent-dev-cluster-source-subscription"
-  topic = google_pubsub_topic.mondo_notifications.name
-
-  # 20 minutes
-  message_retention_duration = "1200s"
-  retain_acked_messages      = true
-
-  ack_deadline_seconds = 20
-
-  expiration_policy {
-    ttl = "300000.5s"
-  }
-  retry_policy {
-    minimum_backoff = "10s"
-  }
-
-  enable_message_ordering = false
-}
-
-resource "google_pubsub_topic_iam_member" "mondo_function" {
-  topic  = google_pubsub_topic.mondo_notifications.name
-  role   = "roles/pubsub.publisher"
-  member = "serviceAccount:${google_service_account.mondo_notifier_func.email}"
-}
-
 # allows for automated cloudbuild deployments
 resource "google_service_account_iam_member" "cloudbuild_mondo_notifier_binding" {
   service_account_id = "projects/clingen-dx/serviceAccounts/${google_service_account.mondo_notifier_func.email}"


### PR DESCRIPTION
This PR removes the pubsub items from the mondo notifier, since we decided to not use the pubsub connector, and to have the function talk directly to our kafka cluster instead.

@larrybabb Are there any _new_ IAM permissions or resources that your function will need? (i.e. any new GCS buckets and/or the ability to write to GCS buckets, access to secrets in the Google Secret Manager, etc)

I'll keep this PR open, and we can add any new stuff to it as you work on the function.