### PR TITLE
remove project level grants, add all-projects bq grants to clingen-data-read

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -24,6 +24,14 @@ module "clingen_projects_iam_bindings" {
       "group:clingen-gcp-admin@broadinstitute.org",
     ]
 
+    "roles/bigquery.jobUser" = [
+      "group:clingen-data-read@broadinstitute.org",
+    ]
+
+    "roles/bigquery.dataViewer" = [
+      "group:clingen-data-read@broadinstitute.org",
+    ]
+
     "roles/cloudbuild.builds.editor" = [
       "group:clingen-gcp-admin@broadinstitute.org",
     ]
@@ -95,31 +103,6 @@ module "clingen_storage_readers_iam" {
       "group:clingen-data-read@broadinstitute.org",
     ]
   }
-}
-
-resource "google_project_iam_member" "clingen_bigquery_prod_readers" {
-  project = "clingen-dx"
-  role    = "roles/bigquery.dataViewer"
-  member  = "group:clingen-data-read@broadinstitute.org"
-}
-
-resource "google_project_iam_member" "clingen_bigquery_prod_cxn_users" {
-  project = "clingen-dx"
-  role    = "roles/bigquery.jobUser"
-  member  = "group:clingen-data-read@broadinstitute.org"
-}
-
-
-resource "google_project_iam_member" "clingen_bigquery_dev_readers" {
-  project = "clingen-dev"
-  role    = "roles/bigquery.dataViewer"
-  member  = "group:clingen-data-read@broadinstitute.org"
-}
-
-resource "google_project_iam_member" "clingen_bigquery_dev_cxn_users" {
-  project = "clingen-dev"
-  role    = "roles/bigquery.jobUser"
-  member  = "group:clingen-data-read@broadinstitute.org"
 }
 
 resource "google_project_iam_custom_role" "cloudfunction_unauthed_perms" {


### PR DESCRIPTION
This adds bigquery read access to the clingen-stage bigquery tables for the clingen-data-read group.

Since we now want these perms across all three projects, I have removed the individual project grants for clingen-dx and clingen-dev, and added the bigquery.jobUser and bigquery.dataViewer grants to the terraform block that applies IAM permissions across all projects.