### PR TITLE
migrate genegraph-dev GKE cluster to new containerd runtime

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -18,22 +18,36 @@ module "cloudbuild-firebase" {
 }
 
 module "dev-gke-cluster" {
-  source                    = "github.com/broadinstitute/tgg-terraform-modules//imported-gke-cluster?ref=ce78edb118f2cd4bdb9d0adec33aa323b92f7a2f"
-  cluster_name              = "genegraph-dev"
-  cluster_location          = "us-east1-b"
-  network_id                = "projects/clingen-dev/global/networks/default"
-  subnetwork_id             = "projects/clingen-dev/regions/us-east1/subnetworks/default"
-  maint_start_time          = "2021-03-24T11:00:00Z"
-  maint_end_time            = "2021-03-24T23:00:00Z"
-  maint_recurrence_sched    = "FREQ=WEEKLY;BYDAY=SA,SU"
-  initial_node_count        = 0
-  default_pool_node_count   = 2
-  default_pool_machine_type = "n1-highmem-2"
-  cluster_v4_cidr           = "10.36.0.0/14"
-  services_v4_cidr          = "10.101.0.0/20"
+  source                   = "github.com/broadinstitute/tgg-terraform-modules//imported-gke-cluster?ref=1679ea8bb0fedfb879bca581624c6c51df6efbfa"
+  cluster_name             = "genegraph-dev"
+  cluster_location         = "us-east1-b"
+  network_id               = "projects/clingen-dev/global/networks/default"
+  subnetwork_id            = "projects/clingen-dev/regions/us-east1/subnetworks/default"
+  maint_start_time         = "2021-03-24T11:00:00Z"
+  maint_end_time           = "2021-03-24T23:00:00Z"
+  maint_recurrence_sched   = "FREQ=WEEKLY;BYDAY=SA,SU"
+  initial_node_count       = 0
+  remove_default_node_pool = true
+  cluster_v4_cidr          = "10.36.0.0/14"
+  services_v4_cidr         = "10.101.0.0/20"
   resource_labels = {
     admin      = "terry"
     creator    = "terry"
     managed_by = "terraform"
+  }
+}
+
+resource "google_container_node_pool" "main-pool" {
+  name       = "main-pool"
+  location   = "us-east1-b"
+  cluster    = module.dev-gke-cluster.gke-cluster-name
+  node_count = 2
+
+  node_config {
+    preemptible     = false
+    machine_type    = "n2-standard-2"
+    image_type      = "COS_CONTAINERD"
+    local_ssd_count = 1
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 }


### PR DESCRIPTION
works on #252 

Looking like the least-downtime approach here is to:

1. update to the imported-gke-cluster module `26fcbffd5441e69e2b3e5fb6fe4e66d0e66a0bbc` release (if not there already)
2. add a new node pool of the containerd image type
3. terraform apply, and wait for the new node pool
4. cordon the default-pool (or ssd-pool nodes in staging's case)
5. `kubectl rollout restart deployment <name>` for each deployment
6. update to imported-gke-cluster module `1679ea8bb0fedfb879bca581624c6c51df6efbfa` release and remove the default node pool configs (if necessary). Staging has its own custom ssd-pool that we'll be removing, rather than the default-pool
7. terraform apply to remove the old node pool.