### PR TITLE
Attempt at consolidating our docker image update pipelines

### DIFF
--- a/dockerfiles/git-image-updater/Dockerfile
+++ b/dockerfiles/git-image-updater/Dockerfile
@@ -12,4 +12,6 @@ RUN apt-get update \
   && rm /tmp/gh-cli.tar.gz \
   && rm -rf /var/lib/apt/lists/*
 
+COPY genegraph_bumper.sh /usr/local/bin/genegraph_bumper.sh
+
 ENTRYPOINT ["/bin/bash"]

--- a/dockerfiles/git-image-updater/genegraph_bumper.sh
+++ b/dockerfiles/git-image-updater/genegraph_bumper.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# invocation: ./genegraph_bumper.sh genegraph abcdef1 "./helm/values/genegraph/values-stage.yaml,./helm/values/genegraph/values-prod.yaml"
+set -euo pipefail
+
+GENEGRAPH_DEPLOYMENT=$1
+COMMIT_SHA=$2
+UPDATE_FILES_LIST=$3
+IFS="," read -ra UPDATE_FILES <<< "$UPDATE_FILES_LIST"
+SHORT_SHA=${COMMIT_SHA:0:7}
+
+# retrieve the architecture repo and check out a branch
+git clone https://clingen-ci:$$GITHUB_TOKEN@github.com/clingen-data-model/architecture
+cd architecture
+git checkout -b image-update-$GENEGRAPH_DEPLOYMENT-$SHORT_SHA # TODO: this needs to be more specific
+
+# generate a datestamp
+date "+%Y-%m-%dT%H%M" > /tmp/DATETIME.txt
+
+# for every file in UPDATE_FILES, update the image tag and data version
+for filename in "${UPDATE_FILES[@]}"
+do
+    /usr/bin/yq eval -i ".genegraph_docker_image_tag = \"$COMMIT_SHA\"" $filename
+    /usr/bin/yq eval -i ".genegraph_data_version = \"$(tr -d '\n' < /tmp/DATETIME.txt)\"" $filename
+done
+
+# commit the changes
+git add -u
+git -c user.name="Clingen CI Automation" -c user.email="clingendevs@broadinstitute.org" commit -m "bumping docker image for ${GENEGRAPH_DEPLOYMENT}"
+git push origin image-update-$GENEGRAPH_DEPLOYMENT-$SHORT_SHA
+gh pr create --fill -l automation


### PR DESCRIPTION
Right now, if you look at the genegraph repo, we've got a bunch of different cloudbuilds that all contain largely the same routine:
1. build docker image
2. create a branch of architecture
3. update the docker image tag (and some other variables) in the helm charts
4. open a PR with the changes

Each cloudbuild has its own (mostly copied) version of those steps in a long bash `&&` chain. To avoid having the same-ish code in 3 places in genegraph, I'm trying to put together a parameterized script that can replace the long chain, and allow for maintaining the steps in a single place.

Right now the script is specific for genegraph, but I'm wondering if it would be worth expanding it so that it can update helm values which are not helm specific.

See also https://github.com/clingen-data-model/genegraph/issues/421