### PR TITLE
Update google provider

### DIFF
--- a/terraform/modules/cloudbuild-firebase/main.tf
+++ b/terraform/modules/cloudbuild-firebase/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.3.0"
+      version = "~> 4.26.0"
     }
   }
 }

--- a/terraform/modules/external-secrets/main.tf
+++ b/terraform/modules/external-secrets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.3.0"
+      version = "~> 4.26.0"
     }
   }
 }

--- a/terraform/prod/cloudbuild_triggers.tf
+++ b/terraform/prod/cloudbuild_triggers.tf
@@ -17,4 +17,6 @@ resource "google_cloudbuild_trigger" "clinvar_scv_prod" {
   ]
 
   filename = "gcp/function-source/cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -12,6 +12,8 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_push" {
   }
 
   filename = ".cloudbuild/docker-build.cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # clinvar-submitter pull request checks
@@ -28,6 +30,8 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_pr" {
   }
 
   filename = ".cloudbuild/pull-request.cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # architecture helm chart linting
@@ -48,6 +52,8 @@ resource "google_cloudbuild_trigger" "architecture_helm_lint" {
   ]
 
   filename = "helm/cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # architecture terraform linting
@@ -69,6 +75,8 @@ resource "google_cloudbuild_trigger" "architecture_tflint" {
   ]
 
   filename = "terraform/cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # curator build
@@ -105,6 +113,8 @@ resource "google_cloudbuild_trigger" "genegraph_stage" {
   }
 
   filename = ".cloudbuild/docker-build.cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # genegraph stage clinvar build
@@ -120,6 +130,8 @@ resource "google_cloudbuild_trigger" "genegraph_stage_clinvar" {
     }
   }
   filename = ".cloudbuild/docker-build-stage-clinvar.cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 # # clinvar streams build
@@ -136,4 +148,6 @@ resource "google_cloudbuild_trigger" "clinvar_streams_build" {
   }
 
   filename = "cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.3.0"
+      version = "~> 4.26.0"
     }
   }
 }


### PR DESCRIPTION
This updates the terraform google provider to 4.26, which apparently enables the previously not-working feature to attach cloudbuild build logs to the github status feature.