### PR TITLE
Clinvarscv function configuration

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -131,3 +131,15 @@ resource "google_service_account_iam_member" "cloudbuild_mondo_notifier_binding"
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:583560269534@cloudbuild.gserviceaccount.com"
 }
+
+resource "google_project_iam_member" "prod_cloudbuild_cloudfunc_developer" {
+  project = "clingen-dx"
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "prod_cloudbuild_cloudfunc_binding" {
+  service_account_id = "projects/clingen-dx/serviceAccounts/clingen-dx@appspot.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -118,3 +118,16 @@ resource "google_project_iam_member" "cloudbuild_iam_manager" {
   role    = google_project_iam_custom_role.cloudfunction_unauthed_perms.name
   member  = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
 }
+
+# grants cloudbuild the cloudfunctions developer role and allows deployments
+resource "google_project_iam_member" "stage_cloudbuild_cloudfunc_developer" {
+  project = "clingen-stage"
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:974091131481@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "cloudbuild_mondo_notifier_binding" {
+  service_account_id = "projects/clingen-stage/serviceAccounts/clingen-stage@appspot.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:583560269534@cloudbuild.gserviceaccount.com"
+}

--- a/terraform/stage/cloudbuild_triggers.tf
+++ b/terraform/stage/cloudbuild_triggers.tf
@@ -34,6 +34,29 @@ resource "google_cloudbuild_trigger" "clinvar_submitter_pr" {
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
+# clinvar-submitter cloudfunction deployment
+resource "google_cloudbuild_trigger" "clinvar_submitter_repo" {
+  name        = "clinvar-scv-gcp-function-push"
+  description = "Redeploy stage ClinVarSCV cloudfunction when the source changes"
+
+  github {
+    name  = "clinvar-submitter"
+    owner = "clingen-data-model"
+    push {
+      branch = "^master$"
+    }
+  }
+
+  included_files = [
+    "gcp/function-source/**"
+  ]
+
+  filename = "gcp/function-source/cloudbuild.yaml"
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}
+
+
 # architecture helm chart linting
 resource "google_cloudbuild_trigger" "architecture_helm_lint" {
   name        = "architecture-helm-pr-lint"


### PR DESCRIPTION
Staging (and likely prod) were lacking automation and permissions to deploy the clinvarscv cloud function.

This PR adds the required permissions, and then configures a cloudbuild trigger to automatically deploy staging when the clinvar-submitter gcp/function-source/* directory changes.

Production already had a build trigger, but it's in a disabled state to allow for manual deployments -- when you want to deploy production, just go to https://console.cloud.google.com/cloud-build/triggers?project=clingen-dx and click the 'Run' button next to the ClinvarSCVChange build trigger.