### PR TITLE
update clinvar ingest external secret to new API

### DIFF
--- a/helm/charts/clingen-clinvar-ingest-updater/templates/secret.yaml
+++ b/helm/charts/clingen-clinvar-ingest-updater/templates/secret.yaml
@@ -1,13 +1,18 @@
-apiVersion: kubernetes-client.io/v1
+---
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: google-account-key-{{ .Release.Name }}
   labels:
     {{- include "clingen-clinvar-ingest-updater.labels" . | nindent 4 }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.project_id }}
   data:
-    - key: {{ .Values.gcp_key_secret_name }}
-      name: key.json
+  - remoteRef:
+      key: {{ .Values.gcp_key_secret_name }}
       version: latest
+    secretKey: key.json
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcpsecretsmanager-secretstore
+  target:
+    name: google-account-key-{{ .Release.Name }}


### PR DESCRIPTION
This updates the externalsecret manifest in the clinvar ingest updater to use the new API provided by the [External Secrets Operator](https://external-secrets.io), which has replaced the old tool that was previously providing that ES api type.

tagging @theferrit32 for review, since I think he's got the only externalsecrets outside of the shared `services/{env}/secrets` directory.

This should be safe to merge once the updated operator is deployed to staging (we don't have an ingest updater in dev or prod)