### PR TITLE
Migrate genegraph secrets

### DIFF
--- a/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: DX_JAAS_CONFIG
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.genegraph_dx_jaas_secretname }}
+                  name: dx-jaas-{{ .Release.Name }}
                   key: password
           ports:
             - containerPort: 8888

--- a/helm/charts/clingen-genegraph/templates/genegraph-secrets.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-secrets.yaml
@@ -1,0 +1,20 @@
+# Syncs the GCP secret named via .Values.genegraph_dx_jaas_secretname var and creates a secret in K8S
+# called dx-jaas-releasename (replace releasename with your genegraph helm release name), with the secret
+# value in a field called 'password'
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dx-jaas-{{ .Release.Name }}
+  labels:
+    {{- include "clingen-genegraph.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcpsecretsmanager-secretstore
+  target:
+    name: dx-jaas-{{ .Release.Name }}
+  data:
+  - secretKey: password
+    remoteRef:
+      key: {{ .Values.genegraph_dx_jaas_secretname }}
+      version: latest


### PR DESCRIPTION
This takes genegraph's only secret, and defines the externalsecret manifest as an object managed by the helm chart (secrets were previously managed out of band).

I've also removed a secret variable (`SERVEUR_KEY_PASS`) from the genegraph Deployment spec which didn't look like we were using.

part of #322 