### PR TITLE
Clinvar raw dedup

### DIFF
--- a/helm/charts/clinvar-raw-stream/pre-deploy-dev-dedup
+++ b/helm/charts/clinvar-raw-stream/pre-deploy-dev-dedup
@@ -31,13 +31,9 @@ echo "Resetting input topic offset"
 topic_offset_to_zero $input_topic $group
 
 echo "Deleting and recreating output topic"
-# leave +e untoggled so topic deletes are allowed to fail
-set +e
-confluent kafka topic delete --cluster $cluster_id $output_topic
+confluent kafka topic delete --cluster $cluster_id $output_topic || true
 sleep 3
-set -e
 
-# switch -e so exits on failure
 confluent kafka topic create --cluster $cluster_id $output_topic \
   --partitions 1 \
   --config retention.ms=-1

--- a/helm/charts/clinvar-raw-stream/pre-deploy-dev-dedup
+++ b/helm/charts/clinvar-raw-stream/pre-deploy-dev-dedup
@@ -1,0 +1,43 @@
+#!/bin/zsh
+set -xeuo pipefail
+
+input_topic=broad-dsp-clinvar
+output_topic=clinvar-raw-dedup
+cluster=clingen-streams-dev
+group=clinvar-raw-dev-dedup
+cluster_id=$(confluent kafka cluster list | grep $cluster | awk '{print $1}')
+
+kafka_properties_file=./kafka-dev.properties
+if [[ ! -f "$kafka_properties_file" ]]; then
+  echo "Kafka properties file not found: $kafka_properties_file "
+  exit 1
+fi
+
+# reset offset on input topic
+function topic_offset_to_zero {
+    topic=$1
+    group=$2
+    kafka-consumer-groups --command-config ./kafka-dev.properties \
+      --bootstrap-server pkc-4yyd6.us-east1.gcp.confluent.cloud:9092 \
+      --reset-offsets \
+      --to-offset 0 \
+      --group "$group" \
+      --topic "$topic" \
+      --timeout 10000 \
+      --execute
+}
+
+echo "Resetting input topic offset"
+topic_offset_to_zero $input_topic $group
+
+echo "Deleting and recreating output topic"
+# leave +e untoggled so topic deletes are allowed to fail
+set +e
+confluent kafka topic delete --cluster $cluster_id $output_topic
+sleep 3
+set -e
+
+# switch -e so exits on failure
+confluent kafka topic create --cluster $cluster_id $output_topic \
+  --partitions 1 \
+  --config retention.ms=-1

--- a/helm/charts/clinvar-raw-stream/templates/clinvar-raw-statefulset.yaml
+++ b/helm/charts/clinvar-raw-stream/templates/clinvar-raw-statefulset.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include  "clinvar-raw.chartLabels" . | nindent 4 }}
 spec:
+  serviceName: {{ .Release.Name }}-svc
   selector:
     matchLabels:
       {{- include "clinvar-raw.selectorLabels" . | nindent 6 }}
@@ -14,6 +15,10 @@ spec:
         {{- include "clinvar-raw.selectorLabels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 600
+      volumes:
+        - name: {{ .Release.Name }}-vol
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-pvc
       containers:
         - image: "{{ .Values.clinvar_streams_docker_image_name }}:{{ .Values.clinvar_streams_docker_image_tag }}"
           imagePullPolicy: {{ .Values.clinvar_streams_image_pull_policy }}
@@ -22,7 +27,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-vol
+              mountPath: "/data/"
           env:
+            - name: CLINVAR_STREAMS_DATA_DIR
+              value: "/data/"
             - name: DX_CV_RAW_INPUT_TOPIC
               value: {{ .Values.clinvar_raw_input_topic }}
             - name: DX_CV_RAW_OUTPUT_TOPIC

--- a/helm/charts/clinvar-raw-stream/templates/persistent-volume-claim.yaml
+++ b/helm/charts/clinvar-raw-stream/templates/persistent-volume-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+  labels:
+    {{- include  "clinvar-raw.chartLabels" . | nindent 4 }}
+spec:
+  storageClassName: {{ .Release.Name }}-storageclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 75Gi

--- a/helm/charts/clinvar-raw-stream/templates/storage-class.yaml
+++ b/helm/charts/clinvar-raw-stream/templates/storage-class.yaml
@@ -1,0 +1,11 @@
+# https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/README.md
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Release.Name }}-storageclass
+  labels:
+    {{- include  "clinvar-raw.chartLabels" . | nindent 4 }}
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  fsType: ext4

--- a/helm/charts/clinvar-raw-stream/values.yaml
+++ b/helm/charts/clinvar-raw-stream/values.yaml
@@ -8,5 +8,4 @@ clinvar_streams_deployment_resources:
     cpu: 0.2
   limits:
     memory: 1Gi
-    cpu: 1
 clinvar_streams_container_args: []

--- a/helm/charts/clinvar-raw-stream/values.yaml
+++ b/helm/charts/clinvar-raw-stream/values.yaml
@@ -8,4 +8,5 @@ clinvar_streams_deployment_resources:
     cpu: 0.2
   limits:
     memory: 1Gi
+    cpu: 4
 clinvar_streams_container_args: []

--- a/helm/values/clinvar-raw-stream/values-dev-dedup.yaml
+++ b/helm/values/clinvar-raw-stream/values-dev-dedup.yaml
@@ -1,0 +1,8 @@
+project_id: clingen-dev
+clinvar_streams_docker_image_name: gcr.io/clingen-dev/clinvar-streams
+clinvar_streams_docker_image_tag: dev-deploy
+clinvar_raw_input_topic: broad-dsp-clinvar
+clinvar_raw_output_topic: clinvar-raw-dedup
+clinvar_streams_kafka_group: clinvar-raw-dev-dedup
+clinvar_streams_container_args:
+  - clinvar-raw


### PR DESCRIPTION
This modifies clinvar-raw stream producer deployment to account for new dedup changes requiring persistent storage (across-pod-restart).

Prior `clinvar-raw` deployment in dev referencing `dev-deploy` docker tag has been terminated, but topic `clinvar-raw` has been kept in place.