### PR TITLE
Update helmfile linter versions

### DIFF
--- a/dockerfiles/helm-linter/Dockerfile
+++ b/dockerfiles/helm-linter/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update \
      wget \
      git \
      ca-certificates \
-  && wget https://github.com/roboll/helmfile/releases/download/v0.139.5/helmfile_linux_amd64 -O /usr/bin/helmfile \
+  && wget https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_linux_amd64 -O /usr/bin/helmfile \
   && chmod +x /usr/bin/helmfile \
-  && wget https://github.com/yannh/kubeconform/releases/download/v0.4.7/kubeconform-linux-amd64.tar.gz -O /tmp/kubeconform.tar.gz \
+  && wget https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-linux-amd64.tar.gz -O /tmp/kubeconform.tar.gz \
   && tar -C /usr/bin -xzf /tmp/kubeconform.tar.gz kubeconform \
   && rm /tmp/kubeconform.tar.gz \
   && wget https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz -O /tmp/helm.tar.gz \

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
       for chart in $(ls charts); do
         echo "===== Linting $chart ====="
         helm lint --with-subcharts=false charts/$chart
-        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig,ExternalSecret" -verbose -kubernetes-version "1.20.8"
+        helmfile -q -l chart=$chart template | kubeconform -strict -skip "ManagedCertificate,BackendConfig,ExternalSecret,CustomResourceDefinition" -verbose -kubernetes-version "1.22.9"
       done
 
 # timeout if not complete in 10 minutes


### PR DESCRIPTION
This updates the helmfile linter docker images to new versions of helmfile and kubeconform. I also updated the version of kubernetes that we validate manifests against to ensure that our charts are still valid for k8s v1.22.