### PR TITLE
Adds a new bucket and object admin access on it to nwc collaborator

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -105,6 +105,21 @@ module "clingen_storage_readers_iam" {
   }
 }
 
+module "nwc_storage_admins_iam" {
+  source  = "terraform-google-modules/iam/google//modules/storage_buckets_iam"
+  version = "7.4.0"
+  mode    = "additive"
+
+  storage_buckets = ["ga4gh-cvc-metakb"]
+
+  bindings = {
+    "roles/storage.objectAdmin" = [
+      "user:Alex.Wagner@nationwidechildrens.org",
+      "user:kori.kuzma@nationwidechildrens.org"
+    ]
+  }
+}
+
 resource "google_project_iam_custom_role" "cloudfunction_unauthed_perms" {
   project     = "clingen-dx"
   role_id     = "cloudbuildFunctionIamManager"

--- a/terraform/stage/storage.tf
+++ b/terraform/stage/storage.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "ga4gh_cvc_metakb" {
+  name          = "ga4gh-cvc-metakb"
+  storage_class = "STANDARD"
+  location      = "us-east1"
+}


### PR DESCRIPTION
This adds a new bucket and allows our collaborators from nationwide children's to administer objects within that bucket.

If they've not used google cloud before, they'll have to authenticate the gcloud cli using their NWC google IDs, as described here: https://cloud.google.com/sdk/docs/authorizing

And they'll need to set their project and location(s):

```
gcloud config set core/project clingen-stage
gcloud config set compute/region us-east1
gcloud config set compute/zone use-east1-b
```

Once this merges, I'll apply the changes to create the bucket and IAM grants by running `terraform apply` in the `terraform/stage` folder, and then the `terraform/shared/iam` folder.