### PR TITLE
Genegraph with redis

### DIFF
--- a/helm/charts/clingen-genegraph/templates/_helpers.tpl
+++ b/helm/charts/clingen-genegraph/templates/_helpers.tpl
@@ -28,6 +28,6 @@ helm.sh/chart: {{ .Chart.Name }}
 {{- end }}
 
 {{- define "genegraph-redis.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ .Release.Name }}-redis
+app.kubernetes.io/instance: {{ .Release.Name }}-redis
 {{- end }}

--- a/helm/charts/clingen-genegraph/templates/_helpers.tpl
+++ b/helm/charts/clingen-genegraph/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{/* 
+{{/*
 genegraph chart helpers
 */}}
 {{- define "clingen-genegraph.labels" -}}
@@ -14,6 +14,20 @@ helm.sh/chart: {{ .Chart.Name }}
 Selector labels
 */}}
 {{- define "clingen-genegraph.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*genegraph redis labels*/}}
+{{- define "genegraph-redis.labels" -}}
+{{ include "genegraph-redis.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}
+{{- end }}
+
+{{- define "genegraph-redis.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
@@ -84,6 +84,10 @@ spec:
             {{- end }}
             - name: GENEGRAPH_BATCH_EVENT_SOURCES
               value: {{ .Values.genegraph_batch_event_sources | quote }}
+            {{- if .Values.genegraph_redis_host }}
+            - name: CACHE_REDIS_URI
+              value: redis://{{- .Values.genegraph_redis_host -}}:{{- .Values.genegraph_redis_port -}}
+            {{- end }}
             - name: DX_JAAS_CONFIG
               valueFrom:
                 secretKeyRef:
@@ -97,6 +101,10 @@ spec:
             - name: genegraph-vol
               mountPath: /data/
           {{- end }}
+          {{- if .Values.genegraph_command }}
+          # Overrides the Docker image CMD
+          command: {{ toYaml .Values.genegraph_command | nindent 12 }}
+          {{- end}}
           {{- with .Values.genegraph_readiness_probe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - name: genegraph-vol
           hostPath:
             path: "/mnt/disks/ssd0/{{ .Release.Name }}"
+        {{- else if .Values.genegraph_persistent_disk }}
+        - name: genegraph-vol
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-pvc
         {{- end }}
       containers:
         - image: {{ .Values.genegraph_docker_image_name }}:{{ .Values.genegraph_docker_image_tag }}
@@ -86,7 +90,7 @@ spec:
               value: {{ .Values.genegraph_batch_event_sources | quote }}
             {{- if .Values.genegraph_redis_host }}
             - name: CACHE_REDIS_URI
-              value: redis://{{- .Values.genegraph_redis_host -}}:{{- .Values.genegraph_redis_port -}}
+              value: redis://{{- tpl .Values.genegraph_redis_host . -}}:{{- .Values.genegraph_redis_port -}}
             {{- end }}
             - name: DX_JAAS_CONFIG
               valueFrom:
@@ -98,6 +102,9 @@ spec:
               name: genegraph-port
           volumeMounts:
           {{- if .Values.genegraph_local_ssd }}
+            - name: genegraph-vol
+              mountPath: /data/
+          {{- else if .Values.genegraph_persistent_disk }}
             - name: genegraph-vol
               mountPath: /data/
           {{- end }}

--- a/helm/charts/clingen-genegraph/templates/genegraph-pvc.yaml
+++ b/helm/charts/clingen-genegraph/templates/genegraph-pvc.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.genegraph_persistent_disk }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+  labels:
+    {{- include "clingen-genegraph.labels" . | nindent 4 }}
+spec:
+  storageClassName: {{ .Release.Name }}-faster
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.genegraph_persistent_disk.size }}
+{{ end }}

--- a/helm/charts/clingen-genegraph/templates/redis.yaml
+++ b/helm/charts/clingen-genegraph/templates/redis.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.genegraph_start_redis }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    {{- include "genegraph-redis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Release.Name }}-redis-svc
+  selector:
+    matchLabels:
+      {{- include "genegraph-redis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "genegraph-redis.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 600
+      volumes:
+        - name: {{ .Release.Name }}-redis-vol
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-redis-pvc
+      containers:
+        - image: {{ .Values.genegraph_redis_image }}
+          imagePullPolicy: Always
+          name: redis
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 0.5
+          volumeMounts:
+            - name: {{ .Release.Name }}-redis-vol
+              mountPath: "/data/"
+          ports:
+            - containerPort: 6379
+              name: redis-port
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis-svc
+  labels:
+    {{- include "genegraph-redis.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "genegraph-redis.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.genegraph_service_type }}
+  ports:
+    - port: {{ .Values.genegraph_redis_port }}
+      targetPort: redis-port
+      protocol: TCP
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-redis-pvc
+  labels:
+    {{- include "genegraph-redis.labels" . | nindent 4 }}
+spec:
+  storageClassName: {{ .Release.Name }}-redis-storageclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+---
+# https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/README.md
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Release.Name }}-redis-storageclass
+  labels:
+    {{- include "genegraph-redis.labels" . | nindent 4 }}
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  fsType: ext4
+{{- end }}

--- a/helm/charts/clingen-genegraph/templates/redis.yaml
+++ b/helm/charts/clingen-genegraph/templates/redis.yaml
@@ -64,7 +64,6 @@ spec:
     requests:
       storage: 50Gi
 ---
-# https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/README.md
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -75,4 +74,5 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd
   fsType: ext4
+allowVolumeExpansion: true
 {{- end }}

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -70,3 +70,7 @@ genegraph_redis_image: redis:7.0
 # Connect to a redis instance.
 # genegraph_redis_host: "{{ .Release.Name }}-redis-svc"
 # genegraph_redis_port: 6379
+
+
+# Overrides the Dockerfile CMD. Can use this to modify main args.
+# genegraph_command: ["java", "-jar", "/app/app.jar"]

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -57,11 +57,16 @@ genegraph_configure_storageclass: true
 genegraph_run_migration: false
 
 # redis cache
-# Starts a redis instance as part of the helm chart
+# An instance of this chart can start a redis instance, and/or connect to a redis instance.
+# For example an upstream cache populating instance can start a redis instance and also connect to it
+# which will put things in the cache. And a downstream genegraph instance can *not* start a redis instance,
+# but just connect to this existing redis instance that was populated by the upstream cache populator.
+# Starts a redis instance as part of the helm chart.
 genegraph_start_redis: false
 genegraph_redis_image: redis:7.0
 # If genegraph_redis_host is defined, will set the envvar REDIS_CACHE_URI.
 # Accepts a template and this commented example will match the generated
 # redis service name "-redis-svc".
+# Connect to a redis instance.
 # genegraph_redis_host: "{{ .Release.Name }}-redis-svc"
 # genegraph_redis_port: 6379

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -49,15 +49,19 @@ genegraph_port: 80
 # storage
 genegraph_local_ssd: true
 genegraph_configure_storageclass: true
+# If set and genegraph_local_ssd is false, will use a pv of this .size
+# genegraph_persistent_disk:
+#   size: 10Gi
 
 # run migration job before deployment
 genegraph_run_migration: false
 
 # redis cache
-# Starts a redis instance as part of a helm chart
+# Starts a redis instance as part of the helm chart
 genegraph_start_redis: false
 genegraph_redis_image: redis:7.0
-# If host is defined, will pass the environment variable CACHE_REDIS_URI
-# And the genegraph application will use that redis host for caching.
-# genegraph_redis_host: <>
+# If genegraph_redis_host is defined, will set the envvar REDIS_CACHE_URI.
+# Accepts a template and this commented example will match the generated
+# redis service name "-redis-svc".
+# genegraph_redis_host: "{{ .Release.Name }}-redis-svc"
 # genegraph_redis_port: 6379

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -54,4 +54,10 @@ genegraph_configure_storageclass: true
 genegraph_run_migration: false
 
 # redis cache
-genegraph_use_redis: false
+# Starts a redis instance as part of a helm chart
+genegraph_start_redis: false
+genegraph_redis_image: redis:7.0
+# If host is defined, will pass the environment variable CACHE_REDIS_URI
+# And the genegraph application will use that redis host for caching.
+# genegraph_redis_host: <>
+# genegraph_redis_port: 6379

--- a/helm/charts/clingen-genegraph/values.yaml
+++ b/helm/charts/clingen-genegraph/values.yaml
@@ -34,7 +34,7 @@ genegraph_liveness_probe:
 genegraph_batch_event_sources: gci-express-json;gci-neo4j-archive;gene-dosage-restored
 
 # certificate and ingress
-genegraph_configure_ingress: true 
+genegraph_configure_ingress: true
 genegraph_tls_cert: true
 genegraph_mcrt_domains:
   - 'genegraph-override-this.clingen.app'
@@ -47,9 +47,11 @@ genegraph_service_type: NodePort
 genegraph_port: 80
 
 # storage
-genegraph_local_ssd: true 
+genegraph_local_ssd: true
 genegraph_configure_storageclass: true
 
 # run migration job before deployment
 genegraph_run_migration: false
 
+# redis cache
+genegraph_use_redis: false

--- a/helm/values/vrs-cache/values-dev.yaml
+++ b/helm/values/vrs-cache/values-dev.yaml
@@ -18,6 +18,9 @@ genegraph_tls_cert: false
 
 # storage
 genegraph_local_ssd: false
+genegraph_configure_storageclass: true
+genegraph_persistent_disk:
+  size: 10Gi
 
 # run migration job before deployment
 genegraph_run_migration: false
@@ -25,9 +28,10 @@ genegraph_run_migration: false
 # Use Redis
 genegraph_start_redis: true
 genegraph_redis_image: redis:7.0
-# If host is defined, will pass the environment variable REDIS_CACHE_URI
-# genegraph_redis_host: vrs-cache
-genegraph_redis_host: vrs-cache.default.svc.cluster.local
+# If genegraph_redis_host is defined, will pass the environment variable REDIS_CACHE_URI
+# Host accepts a template. if genegraph_start_redis, the redis host
+# will be the release name plus "-redis-svc"
+genegraph_redis_host: "{{ .Release.Name }}-redis-svc"
 genegraph_redis_port: 6379
 
 

--- a/helm/values/vrs-cache/values-dev.yaml
+++ b/helm/values/vrs-cache/values-dev.yaml
@@ -1,0 +1,35 @@
+# in order of appearance in the helm templates
+# deployment
+genegraph_docker_image_name: gcr.io/clingen-dev/genegraph
+genegraph_docker_image_tag: 597-all-clinvar-variations
+genegraph_data_version: "2022-02-07T1753:25fb2b9d270ad4a7f7392b1cce0004dad4e0b21d"
+genegraph_image_version_envvar: true
+genegraph_cg_search_topics: "clinvar-raw"
+genegraph_gcs_bucket: genegraph-dev
+genegraph_gql_cache: false
+genegraph_validate_events: false
+genegraph_response_cache: false
+genegraph_experimental_schema: true
+genegraph_dx_jaas_secretname: dx-dev-jaas
+
+# certificate and ingress
+genegraph_configure_ingress: false
+genegraph_tls_cert: false
+
+# storage
+genegraph_local_ssd: false
+
+# run migration job before deployment
+genegraph_run_migration: false
+
+# Use Redis
+genegraph_start_redis: true
+genegraph_redis_image: redis:7.0
+# If host is defined, will pass the environment variable REDIS_CACHE_URI
+# genegraph_redis_host: vrs-cache
+genegraph_redis_host: vrs-cache.default.svc.cluster.local
+genegraph_redis_port: 6379
+
+
+# TODO
+genegraph_command: ["java", "-jar", "/app/app.jar", "vrs-cache"]

--- a/helm/values/vrs-cache/values-dev.yaml
+++ b/helm/values/vrs-cache/values-dev.yaml
@@ -34,6 +34,4 @@ genegraph_redis_image: redis:7.0
 genegraph_redis_host: "{{ .Release.Name }}-redis-svc"
 genegraph_redis_port: 6379
 
-
-# TODO
 genegraph_command: ["java", "-jar", "/app/app.jar", "vrs-cache"]


### PR DESCRIPTION
Features added:
- genegraph helm deploy can optionally start a redis deployment exposed on a cluster service with a persistent disk
- genegraph deployment can optionally connect to a redis host for VRS variant cache access
- genegraph can optionally start with a persistent volume with configurable size. Other still-supported options are using container storage (is ephemeral and within host root filesystem) or local ssd.
- the genegraph docker CMD can be overriden by setting `docker_command` in a values file. Useful for main function args.