### PR TITLE
bumping docker image for genegraph

### DIFF
--- a/helm/values/genegraph/values-prod.yaml
+++ b/helm/values/genegraph/values-prod.yaml
@@ -19,7 +19,7 @@ genegraph_pod_affinity:
               values:
                 - genegraph
 genegraph_docker_image_name: gcr.io/clingen-dx/genegraph
-genegraph_docker_image_tag: db49d3b5e0a0cc3a29b0e18226edd51664c42f48
+genegraph_docker_image_tag: kyle-local-commit
 genegraph_deployment_resources:
   requests:
     memory: 6Gi
@@ -27,7 +27,7 @@ genegraph_deployment_resources:
   limits:
     memory: 10Gi
 genegraph_image_version_envvar: true
-genegraph_data_version: "2022-11-28T2232"
+genegraph_data_version: "2022-11-29T1843:kyle-local-commit"
 genegraph_cg_search_topics: "gene-validity-raw;gci-legacy-report-only;actionability;gene-dosage-jira"
 genegraph_batch_event_sources: "gci-raw-snapshot;gene-dosage-restored;gci-raw-missing-data;gci-express-json;gci-neo4j-report-only"
 genegraph_experimental_schema: true

--- a/helm/values/genegraph/values-stage.yaml
+++ b/helm/values/genegraph/values-stage.yaml
@@ -17,7 +17,7 @@ genegraph_pod_affinity:
               values:
                 - genegraph
 genegraph_docker_image_name: gcr.io/clingen-stage/genegraph
-genegraph_docker_image_tag: db49d3b5e0a0cc3a29b0e18226edd51664c42f48
+genegraph_docker_image_tag: kyle-local-commit
 genegraph_deployment_resources:
   requests:
     memory: 6Gi
@@ -25,7 +25,7 @@ genegraph_deployment_resources:
   limits:
     memory: 10Gi
 genegraph_image_version_envvar: true
-genegraph_data_version: "2022-11-28T2232"
+genegraph_data_version: "2022-11-29T1843:kyle-local-commit"
 genegraph_cg_search_topics: "gene-validity-raw;gci-legacy-report-only;actionability;gene-dosage-jira"
 genegraph_batch_event_sources: "gci-raw-snapshot;gene-dosage-restored;gci-raw-missing-data;gci-express-json;gci-neo4j-report-only"
 genegraph_experimental_schema: true


### PR DESCRIPTION
Latest author: kferrite@broadinstitute.org 
Latest subject: Include COMMIT_SHA in .genegraph_data_version
Cause PR: https://github.com/clingen-data-model/genegraph/pull/fake