### PR TITLE
grant owner role to SRE admin group

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -122,6 +122,10 @@ module "clingen_projects_iam_bindings" {
       "group:clingendevs@broadinstitute.org",
       "group:clingen-geisinger-external@broadinstitute.org",
     ]
+
+    "roles/owner" = [
+      "group:tgg-sre-admin@broadinstitute.org",
+    ]
   }
 }
 

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -5,7 +5,7 @@ generate "terraform" {
   if_exists = "overwrite_terragrunt"
   contents = <<EOF
 terraform {
-  required_version = ">= 1.0.0, < 1.5.0"
+  required_version = ">= 1.0.0, < 2.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
This grants the owner role on the clingen projects to the tgg-sre-admin google group, which contains Ben B. and I. This is for allowing Ben to assist with SRE tasks as needed.