### PR TITLE
Vrs cache updates

### DIFF
--- a/helm/charts/clingen-vicc/docker/variation-normalizer/build-patch.sh
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/build-patch.sh
@@ -4,12 +4,9 @@ set -xeuo pipefail
 
 registry_ns=gcr.io/clingen-dev
 repo_dir=variation-normalization
-repo_name=theferrit32/variation-normalization
-# bioutils-large-seqs branches from queryhandler-concurrent-access-fix
-# Includes queryhandler mutex and Dockerfile that uses fork of bioutils
-repo_commit=bioutils-large-seqs
+repo_name=cancervariants/variation-normalization
+repo_commit=0b299fe4dc8d4732d62a23bdd215ec13022130d0
 repo=https://github.com/${repo_name}.git
-
 
 if [ ! -d $repo_dir/.git ]; then
     git clone $repo $repo_dir
@@ -21,6 +18,11 @@ fi
 
 cp start_servers.py $repo_dir/
 cp varnorm-nginx-template.conf $repo_dir/
+cp main_new.py $repo_dir/variation/main.py
+
+# Add version limit to pydantic
+cp $repo_dir/setup.cfg $repo_dir/setup.cfg.bkp
+sed 's/ pydantic\s*$/ pydantic < 2.0.0/g' $repo_dir/setup.cfg.bkp > $repo_dir/setup.cfg
 
 image=gcr.io/clingen-dev/variation-normalization:clingen-updates
 docker build -t $image -f replacement-Dockerfile-nginx $repo_dir

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/replacement-Dockerfile
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/replacement-Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 
 RUN pip install --pre .
 # Run a fork of bioutils
-RUN pip install git+https://github.com/theferrit32/bioutils.git@47-large-seq-normalization
+#RUN pip install git+https://github.com/theferrit32/bioutils.git@47-large-seq-normalization
+RUN pip install git+https://github.com/biocommons/bioutils.git@0.5.8.pre1
 
 EXPOSE 80
 HEALTHCHECK --interval=5m --timeout=3s \

--- a/helm/charts/clingen-vicc/templates/managed-certificate.yaml
+++ b/helm/charts/clingen-vicc/templates/managed-certificate.yaml
@@ -4,9 +4,7 @@ kind: ManagedCertificate
 metadata:
   name: {{ .Release.Name }}-certificate
   labels:
-    #app: hello
     {{- include "clingen-vicc.labels" . | nindent 4 }}
-    #- include "clingen-vicc.selectorLabels" . | nindent 4 }}
 spec:
   domains:
   {{- range .Values.varnorm_mcrt_domains }}

--- a/helm/charts/clingen-vicc/templates/variant-normalizer.yaml
+++ b/helm/charts/clingen-vicc/templates/variant-normalizer.yaml
@@ -63,8 +63,9 @@ spec:
           resources:
             requests:
               cpu: 0.5
+              memory: 4Gi
             limits:
-              memory: 2Gi
+              memory: 4Gi
           ports:
             - containerPort: {{ .Values.varnorm_container_port }}
               # name: varnorm-port


### PR DESCRIPTION
This PR drops the forks of bioutils and variation-normalizer.

bioutils fork was merged, can use a dev tag upstream.

variation-normalizer was not merged but can still be patched on the fly by copying in one file. This file `main.py` just needs to be kept in sync with upstream changes.

Also includes some fixes to `start_servers.py`