### PR TITLE
Update main.tf - added bqadmin role to clingendevs

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -22,6 +22,7 @@ module "clingen_projects_iam_bindings" {
 
     "roles/bigquery.admin" = [
       "group:clingen-gcp-admin@broadinstitute.org",
+      "group:clingendevs@broadinstitute.org",
     ]
 
     "roles/bigquery.jobUser" = [


### PR DESCRIPTION
clingen devs need to have bq admin access in general. at a later time we could consider defining more specialized roles.