### PR TITLE
update memory threshold on genegraph limit util alarm

### DIFF
--- a/terraform/prod/monitoring.tf
+++ b/terraform/prod/monitoring.tf
@@ -90,12 +90,12 @@ resource "google_monitoring_alert_policy" "genegraph_prod_mem_util_alert_policy"
   display_name = "genegraph memory limit utilization"
   combiner     = "OR"
   conditions {
-    display_name = "memory limit utilization is greater than 60%"
+    display_name = "memory limit utilization is greater than 80%"
     condition_threshold {
       filter          = "metric.type=\"kubernetes.io/container/memory/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"prod-cluster\" resource.label.\"container_name\"=\"genegraph\" metric.label.\"memory_type\"=\"non-evictable\""
       duration        = "300s"
       comparison      = "COMPARISON_GT"
-      threshold_value = "0.6"
+      threshold_value = "0.8"
       aggregations {
         alignment_period   = "60s"
         per_series_aligner = "ALIGN_MEAN"
@@ -119,8 +119,8 @@ resource "google_monitoring_alert_policy" "prod_node_allocatable_memory_utilizat
       comparison      = "COMPARISON_GT"
       threshold_value = "0.75"
       aggregations {
-        alignment_period     = "360s"
-        per_series_aligner   = "ALIGN_MEAN"
+        alignment_period   = "360s"
+        per_series_aligner = "ALIGN_MEAN"
       }
     }
   }


### PR DESCRIPTION
Looks like we're hovering right around 60%, this PR should silence the alarm until we understand whether we need to increase the alarm threshold, or adjust the pod request/limit spec.