### PR TITLE
Fix varnorm restarts

### DIFF
--- a/helm/charts/clingen-vicc/docker/variation-normalizer/cloudbuild-vrs-2.yaml
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/cloudbuild-vrs-2.yaml
@@ -39,5 +39,5 @@ images:
 - 'gcr.io/clingen-dev/cancervariants/variation-normalization:$_VARNORM_REVISION'
 
 substitutions:
-  # This is on branch issue-518
-  _VARNORM_REVISION: 26f812e
+  # This is on branch staging
+  _VARNORM_REVISION: af9fde6

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/replacement-Dockerfile-nginx
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/replacement-Dockerfile-nginx
@@ -26,4 +26,4 @@ HEALTHCHECK --interval=5m --timeout=3s \
 ENV varnorm_ports=8010,8011,8012,8013
 
 # Could put this in a script and call that, but this works fine for now
-CMD python -c "import start_servers; start_servers.write_nginx_conf('varnorm-nginx-template.conf', 'varnorm-nginx-generated.conf', [{'host':'127.0.0.1', 'port': p} for p in [${varnorm_ports}]])" && nginx -p $(pwd) -c varnorm-nginx-generated.conf && python -c "import cool_seq_tool" && python start_servers.py "${varnorm_ports}" varnorm-nginx-generated.conf
+CMD python -c "import start_servers; start_servers.write_nginx_conf('varnorm-nginx-template.conf', 'varnorm-nginx-generated.conf', [{'host':'127.0.0.1', 'port': p} for p in [${varnorm_ports}]])" && nginx -p $(pwd) -c varnorm-nginx-generated.conf && python -c "import cool_seq_tool" && python -u start_servers.py "${varnorm_ports}" varnorm-nginx-generated.conf

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/start_servers.py
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/start_servers.py
@@ -79,6 +79,9 @@ def main(argv):
         print(f"sp: {sp}")
         start_on_port(**sp)
 
+    last_printed_success_time = time.time()
+    printed_this_time = False
+
     while len([p for p in processes if p["process"].returncode is None]) > 0:
         need_to_restart = []
         for p in processes:
@@ -88,7 +91,10 @@ def main(argv):
             returncode = proc.poll()
             if returncode is None:
                 # Still running
-                print(f"Process {proc.pid} on {host}:{port} still running")
+                # print still running status only after 5 min
+                if time.time() - last_printed_success_time >= 60*5:
+                    printed_this_time = True
+                    print(f"Process {proc.pid} on {host}:{port} still running")
             else:
                 print(f"Process {proc.pid} on {host}:{port} has terminated "
                       f"with status code {returncode}")
@@ -100,6 +106,9 @@ def main(argv):
             print(f"Restarting dead worker on {host}:{port}")
             processes.remove(p)
             start_on_port(port, host)
+        if printed_this_time:
+            last_printed_success_time = time.time()
+            printed_this_time = False
         time.sleep(5)
 
 

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/start_servers.py
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/start_servers.py
@@ -57,6 +57,7 @@ def write_nginx_conf(template_filename: str,
     with open(output_filename, "w", encoding="UTF-8") as fout:
         fout.write(generate_nginx_conf(template_filename, start_params))
 
+
 def main(argv):
     """
     ./start_servers.py 1000,1001,1002 output-nginx-filename.conf
@@ -84,12 +85,13 @@ def main(argv):
             proc = p["process"]
             host = p["host"]
             port = p["port"]
-            if proc.returncode is None:
+            returncode = proc.poll()
+            if returncode is None:
                 # Still running
-                print("All processes still running")
+                print(f"Process {proc.pid} on {host}:{port} still running")
             else:
-                print(("Process {proc.pid} on {host}:{port} has terminated "
-                       "with status code {proc.returncode}"))
+                print(f"Process {proc.pid} on {host}:{port} has terminated "
+                      f"with status code {returncode}")
                 # Remove P, and start again. start_on_port appends it back
                 need_to_restart.append(p)
         for p in need_to_restart:

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/varnorm-nginx-template.conf
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/varnorm-nginx-template.conf
@@ -4,6 +4,9 @@ events {
 
 http {
     upstream varnorm_backend {
+        ;; 'least_conn' is an nginx load balancing algorithm that sends incoming requests
+        ;; to the backend server that has the least open connections, ensuring no are idle while
+        ;; one is doing all the work.
         least_conn;
 {{server_list}}
     }

--- a/helm/charts/clingen-vicc/docker/variation-normalizer/varnorm-nginx-template.conf
+++ b/helm/charts/clingen-vicc/docker/variation-normalizer/varnorm-nginx-template.conf
@@ -4,9 +4,9 @@ events {
 
 http {
     upstream varnorm_backend {
-        ;; 'least_conn' is an nginx load balancing algorithm that sends incoming requests
-        ;; to the backend server that has the least open connections, ensuring no are idle while
-        ;; one is doing all the work.
+        # 'least_conn' is an nginx load balancing algorithm that sends incoming requests
+        # to the backend server that has the least open connections, ensuring no are idle while
+        # one is doing all the work.
         least_conn;
 {{server_list}}
     }

--- a/helm/values/clingen-vicc/values-vrs-2.yaml
+++ b/helm/values/clingen-vicc/values-vrs-2.yaml
@@ -20,4 +20,4 @@ varnorm_mcrt_domains:
 run_gene_normalizer: true
 
 
-varnorm_docker_image: gcr.io/clingen-dev/cancervariants/variation-normalization:26f812e
+varnorm_docker_image: gcr.io/clingen-dev/cancervariants/variation-normalization:af9fde6


### PR DESCRIPTION
This fixes the issue where `start_servers.py` was not noticing when a forked subprocess died. `subprocess` requires you to call `poll()` to check the status of the process, and `poll()` updates (and returns) the `returncode` attribute. 

I also turned off stdout buffering on the `start_servers.py` script in Dockerfile-nginx. Previously the `print` calls in the script would not be immediately flushed and thus wouldn't show up in the cloud console log until the stdout buffer was full, which could be minutes later. Now it flushes every `print()`.

Also reduced log noise when processes are still running successfully. Only prints a success message every 5 minutes instead of every 5 seconds.