### PR TITLE
Minor update to clinvar-ingest iam

### DIFF
--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -372,3 +372,11 @@ resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-storage-object
   member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
   project = "clingen-dev"
 }
+
+resource "google_service_account_iam_member" "clinvar-ingest-pipeline-deployment-iam" {
+  # service_account_id = google_service_account.clinvar-ingest-deployment.id
+  service_account_id = google_service_account.clinvar-ingest-pipeline-dev.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.clinvar-ingest-deployment.email}"
+  # member             = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+}

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -340,6 +340,12 @@ resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-storage-objec
   member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
   project = "clingen-dx"
 }
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-log-writer" {
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+  project = "clingen-dx"
+}
+
 
 # DEV clinvar-ingest-pipeline service account configuration
 resource "google_service_account" "clinvar-ingest-pipeline-dev" {
@@ -369,6 +375,11 @@ resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-storage-object
 }
 resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-storage-object-viewer" {
   role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+  project = "clingen-dev"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-log-writer" {
+  role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
   project = "clingen-dev"
 }

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -309,34 +309,66 @@ module "gh_oidc" {
   }
 }
 
-# clinvar-ingest-pipeline service account configuration
-resource "google_service_account" "clinvar-ingest-pipeline" {
+# PROD clinvar-ingest-pipeline service account configuration
+resource "google_service_account" "clinvar-ingest-pipeline-prod" {
   project = "clingen-dx"
   account_id   = "clinvar-ingest-pipeline"
   display_name = "Service account for clinvar-ingest pipeline components"
 }
-resource "google_project_iam_member" "clinvar-ingest-pipeline-bigquery-admin" {
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-bigquery-admin" {
   role    = "roles/bigquery.admin"
-  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline.email}"
-  project = "clingen-dev"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
+  project = "clingen-dx"
 }
-resource "google_project_iam_member" "clinvar-ingest-pipeline-cloudrun-invoker" {
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-cloudrun-invoker" {
   role    = "roles/run.invoker"
-  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline.email}"
-  project = "clingen-dev"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
+  project = "clingen-dx"
 }
-resource "google_project_iam_member" "clinvar-ingest-pipeline-workflows-invoker" {
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-workflows-invoker" {
   role    = "roles/workflows.invoker"
-  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline.email}"
-  project = "clingen-dev"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
+  project = "clingen-dx"
 }
-resource "google_project_iam_member" "clinvar-ingest-pipeline-storage-object-creator" {
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-storage-object-creator" {
   role    = "roles/storage.objectCreator"
-  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline.email}"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
+  project = "clingen-dx"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-prod-storage-object-viewer" {
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-prod.email}"
+  project = "clingen-dx"
+}
+
+# DEV clinvar-ingest-pipeline service account configuration
+resource "google_service_account" "clinvar-ingest-pipeline-dev" {
+  project = "clingen-dev"
+  account_id   = "clinvar-ingest-pipeline"
+  display_name = "Service account for clinvar-ingest pipeline components"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-bigquery-admin" {
+  role    = "roles/bigquery.admin"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
   project = "clingen-dev"
 }
-resource "google_project_iam_member" "clinvar-ingest-pipeline-storage-object-viewer" {
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-cloudrun-invoker" {
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+  project = "clingen-dev"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-workflows-invoker" {
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+  project = "clingen-dev"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-storage-object-creator" {
+  role    = "roles/storage.objectCreator"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
+  project = "clingen-dev"
+}
+resource "google_project_iam_member" "clinvar-ingest-pipeline-dev-storage-object-viewer" {
   role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline.email}"
+  member  = "serviceAccount:${google_service_account.clinvar-ingest-pipeline-dev.email}"
   project = "clingen-dev"
 }

--- a/terraform/shared/iam/main.tf
+++ b/terraform/shared/iam/main.tf
@@ -275,6 +275,12 @@ resource "google_cloud_run_service_iam_member" "clinvar-ingest-cloudrun-editor" 
   location = "us-central1"
 }
 
+resource "google_project_iam_member" "clinvar-ingest-cloudrun-editor" {
+  role = "roles/run.developer"
+  member = "serviceAccount:${google_service_account.clinvar-ingest-deployment.email}"
+  project = "clingen-dev"
+}
+
 resource "google_service_account_iam_member" "clinvar-ingest-service-account-user" {
   service_account_id  = "projects/clingen-dev/serviceAccounts/522856288592-compute@developer.gserviceaccount.com"
   role                = "roles/iam.serviceAccountUser"


### PR DESCRIPTION
This sets up a separate clinvar-ingest pipeline account for dev and prod. 

Also enables the clinvar-ingest deployment account (dev) to use the pipeline account, which is needed for some reason when the deployment account is configuring the cloud run service to run as the pipeline account.